### PR TITLE
Added sysl time codegen tag differentiator

### DIFF
--- a/codegen/testdata/simple/simple.sysl
+++ b/codegen/testdata/simple/simple.sysl
@@ -29,6 +29,9 @@ Simple "Simple Server" [package="simple"]:
         sensitiveStuff <: string:
             @json_tag = "sensitiveStuff"
             @sensitive = "true"
+        rawTimeStuff <: DATETIME:
+            @json_tag = "rawTimeStuff"
+            @time_format = "stdtime"
         timeStuff <: DATETIME:
             @json_tag = "timeStuff"
         responseStuff <: Response:

--- a/codegen/tests/simple/simple_test.go
+++ b/codegen/tests/simple/simple_test.go
@@ -202,7 +202,7 @@ func TestHandlerValid(t *testing.T) {
 	resp := w.Result()
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
-	require.JSONEq(t, `{"emptyStuff":{}, "innerStuff":"response","responseStuff":{"Data":{"M":{"James":{"A1":"SpencerSt", "A2":"CollinsSt"}, "John":{"A1":"CollinsSt", "A2":"LonasDaleSt"}}}}, "sensitiveStuff":"****************", "timeStuff":"0001-01-01T00:00:00.000+0000"}`, string(body))
+	require.JSONEq(t, `{"emptyStuff":{}, "innerStuff":"response", "rawTimeStuff":"0001-01-01T00:00:00Z", "responseStuff":{"Data":{"M":{"James":{"A1":"SpencerSt", "A2":"CollinsSt"}, "John":{"A1":"CollinsSt", "A2":"LonasDaleSt"}}}}, "sensitiveStuff":"****************", "timeStuff":"0001-01-01T00:00:00.000+0000"}`, string(body))
 }
 
 func TestRawHandlerValid(t *testing.T) {
@@ -394,7 +394,34 @@ func TestClient_PassesXMLBody(t *testing.T) {
 func TestSensitive(t *testing.T) {
 	logger, hook := test.NewNullLogger()
 	logger.Error(Stuff{InnerStuff: "innerStuff", SensitiveStuff: common.NewSensitiveString("sensitiveStuff")})
-	require.Equal(t, "{{} innerStuff {{map[]}} **************** 0001-01-01 00:00:00 +0000 UTC}", hook.LastEntry().Message)
+	require.Equal(t, "{{} innerStuff 0001-01-01 00:00:00 +0000 UTC {{map[]}} **************** 0001-01-01 00:00:00 +0000 UTC}", hook.LastEntry().Message)
+}
+
+func TestTimeFormat(t *testing.T) {
+	stuff := Stuff{}
+	isStdTime := func(s interface{}) bool {
+		switch s.(type) {
+		case time.Time:
+			return true
+		default:
+			return false
+		}
+	}
+
+	isConvertTime := func(s interface{}) bool {
+		switch s.(type) {
+		case convert.JSONTime:
+			return true
+		default:
+			return false
+		}
+	}
+
+	require.True(t, isStdTime(stuff.RawTimeStuff))
+	require.False(t, isConvertTime(stuff.RawTimeStuff))
+
+	require.True(t, isConvertTime(stuff.TimeStuff))
+	require.False(t, isStdTime(stuff.TimeStuff))
 }
 
 func TestCommentsPassed(t *testing.T) {

--- a/codegen/tests/simple/types.go
+++ b/codegen/tests/simple/types.go
@@ -37,6 +37,7 @@ type Status struct {
 type Stuff struct {
 	EmptyStuff     Empty                  `json:"emptyStuff"`
 	InnerStuff     string                 `json:"innerStuff"`
+	RawTimeStuff   time.Time              `json:"rawTimeStuff"`
 	ResponseStuff  Response               `json:"responseStuff"`
 	SensitiveStuff common.SensitiveString `json:"sensitiveStuff"`
 	TimeStuff      convert.JSONTime       `json:"timeStuff"`

--- a/codegen/transforms/svc_types.sysl
+++ b/codegen/transforms/svc_types.sysl
@@ -26,7 +26,7 @@ CodeGenTransform:
           "STRING_8" => "string"
           "BOOL" => "bool"
           "DATE" => "date.Date"
-          "DATETIME" => "convert.JSONTime"
+          "DATETIME" => if "time_format" in t.attrs then if "stdtime" == t.attrs.time_format then "time.Time" else "convert.JSONTime" else "convert.JSONTime"
         "sequence" => "[]" + GoType(t.sequence).out
         "set" => GoType(t.set).out + "Set"
         else GoName(t.type_ref).out


### PR DESCRIPTION
Closes #35 

Adds a tag differentiator for sysl time data type. By default it will generate a DATETIME primitive type to convert.JSONType as the data format. Adding a tag: @time_format = "stdtime" will code generate to time.Time

Not sure where to put the docs for this??