### PR TITLE
Add go mod tidy check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,3 +35,7 @@ jobs:
 
       - name: Run tests
         run: make check-coverage
+
+      - name: Check go mod is tidy
+        run: make check-tidy
+

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ lint: ## Lint Go Source Code
 tidy: ## Run go mod tidy
 	go mod tidy
 
-.PHONY: lint tidy
+check-tidy: ## Check go.mod and go.sum is tidy
+	go mod tidy && test -z "$$(git status --porcelain)"
+
+.PHONY: lint tidy check-tidy
 
 # -- Test ----------------------------------------------------------------------
 COVERFILE=coverage.out


### PR DESCRIPTION
A common issue for go developers is they forget to run go mod tidy before committing a change. This results in unused references being left in the `go.mod` file.

This PR adds a check for go mod tidiness as suggested in https://github.com/anz-bank/sysl-go/issues/6#issuecomment-601015906