### PR TITLE
fix duplicated DownstreamConfig fields

### DIFF
--- a/codegen/testdata/simple/simple.sysl
+++ b/codegen/testdata/simple/simple.sysl
@@ -29,6 +29,11 @@ Simple "Simple Server" [package="simple"]:
             Deps <- GET /api-docs
             return ok <: Deps.ApiDoc
 
+    /simple-api-docs:
+        GET:
+            Deps <- GET /api-docs
+            return ok <: Deps.ApiDoc
+
     # /no-return-type:
     #     GET:
     #         return

--- a/codegen/tests/cardspb/cards.pb.go
+++ b/codegen/tests/cardspb/cards.pb.go
@@ -5,8 +5,9 @@ package cardspb
 
 import (
 	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
 	math "math"
+
+	proto "github.com/golang/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/codegen/tests/cardspb/cards_api.pb.go
+++ b/codegen/tests/cardspb/cards_api.pb.go
@@ -6,11 +6,12 @@ package cardspb
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/codegen/tests/cardspb/wallet_api.pb.go
+++ b/codegen/tests/cardspb/wallet_api.pb.go
@@ -6,11 +6,12 @@ package cardspb
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/codegen/tests/simple/serviceinterface.go
+++ b/codegen/tests/simple/serviceinterface.go
@@ -51,6 +51,11 @@ type GetRawListClient struct {
 type GetRawIntListClient struct {
 }
 
+// GetSimpleAPIDocsList Client
+type GetSimpleAPIDocsListClient struct {
+	GetApiDocsList func(ctx context.Context, req *deps.GetApiDocsListRequest) (*deps.ApiDoc, error)
+}
+
 // GetStuffList Client
 type GetStuffListClient struct {
 }
@@ -69,6 +74,7 @@ type ServiceInterface struct {
 	GetOopsList               func(ctx context.Context, req *GetOopsListRequest, client GetOopsListClient) (*Response, error)
 	GetRawList                func(ctx context.Context, req *GetRawListRequest, client GetRawListClient) (*Str, error)
 	GetRawIntList             func(ctx context.Context, req *GetRawIntListRequest, client GetRawIntListClient) (*Integer, error)
+	GetSimpleAPIDocsList      func(ctx context.Context, req *GetSimpleAPIDocsListRequest, client GetSimpleAPIDocsListClient) (*deps.ApiDoc, error)
 	GetStuffList              func(ctx context.Context, req *GetStuffListRequest, client GetStuffListClient) (*Stuff, error)
 	PostStuff                 func(ctx context.Context, req *PostStuffRequest, client PostStuffClient) (*Str, error)
 }

--- a/codegen/tests/simple/types.go
+++ b/codegen/tests/simple/types.go
@@ -80,6 +80,10 @@ type GetRawListRequest struct {
 type GetRawIntListRequest struct {
 }
 
+// GetSimpleAPIDocsListRequest ...
+type GetSimpleAPIDocsListRequest struct {
+}
+
 // GetStuffListRequest ...
 type GetStuffListRequest struct {
 	Dt *convert.JSONTime

--- a/codegen/tests/simplepb/simplegrpc.pb.go
+++ b/codegen/tests/simplepb/simplegrpc.pb.go
@@ -6,11 +6,12 @@ package simplepb
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/codegen/transforms/svc_interface.sysl
+++ b/codegen/transforms/svc_interface.sysl
@@ -296,7 +296,10 @@ CodeGenTransform:
               Type =  "time.Duration"
               Tag = '`yaml:"contextTimeout"`'
             )
-            let depList = makeClientImportList(app, module) flatten(.out) -> <sequence of FieldDecl> (importPath:
+            let downstreamAppList = makeClientImportList(app, module) flatten(.out) -> <set of string>(i:
+              out = i
+            )
+            let depList = downstreamAppList flatten(.out) -> <sequence of FieldDecl> (importPath:
               identifier = GoName(importPath).out
               Type =  "config.CommonDownstreamData"
               Tag = '`yaml:"' + importPath + '"`'

--- a/core/testdata/proto/test.pb.go
+++ b/core/testdata/proto/test.pb.go
@@ -6,11 +6,12 @@ package test
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
Fixed #57.

Changes:
- added tests to test multiple invocations of the same app
- fixed duplicated DownstreamConfig fields. It needs to be a `set of` inside another `set of`.