### PR TITLE
Auto-bump minor version on each merge on master

### DIFF
--- a/.github/workflows/generate-tag.yaml
+++ b/.github/workflows/generate-tag.yaml
@@ -1,0 +1,24 @@
+name: Generate-Tag
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  generate-tag:
+    name: Generate tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+        with:
+          fetch-depth: '0'
+
+      # If no #major, #minor or #patch tag is contained in the commit messages, 
+      # it will bump whichever DEFAULT_BUMP is set to (which is minor by default).
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.19.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true


### PR DESCRIPTION
Fixed #25.

Changes:
- Auto-bump minor version on each merge on master

NOTE:
- Major versions are going to be released manually.
- Since commit 9f67a0b in master is backwards incompatible, this PR could be merged after v1.0.0 released.
- We can enable "Require review from Code Owners" in Branch protection rule setting and add `CODEOWNERS` file in `sysl-go` to prevent breaking changes being easily merged into master