### PR TITLE
Populate model dependencies in make

### DIFF
--- a/codegen/testdata/dbendpoints/Module.mk
+++ b/codegen/testdata/dbendpoints/Module.mk
@@ -24,17 +24,19 @@ db-clean:
 clean: db-clean
 gen: db-gen
 
-$(DB_TYPES): $(TRANSFORMS)/svc_types.sysl $(MODEL)
+DB_SYSL=$(TEST_IN_DIR)/$(DB_IN)/dbendpoints.sysl
+
+$(DB_TYPES): $(TRANSFORMS)/svc_types.sysl $(DB_SYSL)
 	$(run-sysl)
 
-$(DB_INTERFACE): $(TRANSFORMS)/svc_interface.sysl $(MODEL)
+$(DB_INTERFACE): $(TRANSFORMS)/svc_interface.sysl $(DB_SYSL)
 	$(run-sysl)
 
-$(DB_HANDLER): $(TRANSFORMS)/svc_handler.sysl $(MODEL)
+$(DB_HANDLER): $(TRANSFORMS)/svc_handler.sysl $(DB_SYSL)
 	$(run-sysl)
 
-$(DB_ROUTER): $(TRANSFORMS)/svc_router.sysl $(MODEL)
+$(DB_ROUTER): $(TRANSFORMS)/svc_router.sysl $(DB_SYSL)
 	$(run-sysl)
 
-$(DB_CLIENT): $(TRANSFORMS)/svc_client.sysl $(MODEL)
+$(DB_CLIENT): $(TRANSFORMS)/svc_client.sysl $(DB_SYSL)
 	$(run-sysl)

--- a/codegen/testdata/simple/Module.mk
+++ b/codegen/testdata/simple/Module.mk
@@ -22,22 +22,24 @@ simple-gen: $(SIMPLE_ALL_FILES)
 simple-clean:
 	rm $(SIMPLE_ALL_FILES)
 
-$(SIMPLE_ERRORS): $(TRANSFORMS)/svc_error_types.sysl $(MODEL)
+SIMPLE_SYSL=$(TEST_IN_DIR)/$(SIMPLE_IN)/simple.sysl
+
+$(SIMPLE_ERRORS): $(TRANSFORMS)/svc_error_types.sysl $(SIMPLE_SYSL)
 	$(run-sysl)
 
-$(SIMPLE_TYPES): $(TRANSFORMS)/svc_types.sysl $(MODEL)
+$(SIMPLE_TYPES): $(TRANSFORMS)/svc_types.sysl $(SIMPLE_SYSL)
 	$(run-sysl)
 
-$(SIMPLE_INTERFACE): $(TRANSFORMS)/svc_interface.sysl $(MODEL)
+$(SIMPLE_INTERFACE): $(TRANSFORMS)/svc_interface.sysl $(SIMPLE_SYSL)
 	$(run-sysl)
 
-$(SIMPLE_HANDLER): $(TRANSFORMS)/svc_handler.sysl $(MODEL)
+$(SIMPLE_HANDLER): $(TRANSFORMS)/svc_handler.sysl $(SIMPLE_SYSL)
 	$(run-sysl)
 
-$(SIMPLE_ROUTER): $(TRANSFORMS)/svc_router.sysl $(MODEL)
+$(SIMPLE_ROUTER): $(TRANSFORMS)/svc_router.sysl $(SIMPLE_SYSL)
 	$(run-sysl)
 
-$(SIMPLE_CLIENT): $(TRANSFORMS)/svc_client.sysl $(MODEL)
+$(SIMPLE_CLIENT): $(TRANSFORMS)/svc_client.sysl $(SIMPLE_SYSL)
 	$(run-sysl)
 
 # Deps Server


### PR DESCRIPTION
Make was not noticing when models changed and so did not rebuild the outputs.

The issue was due to the target-specific variable `$(MODEL)` not being populated in prerequisites. Instead of using `.SECONDEXPANSION` to solve the problem, the pre-requisite is now specified as a normal variable.