### PR TITLE
Move ReadConfig to LoadConfig and validate

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/anz-bank/sysl-go/validator"
 	"io/ioutil"
 
 	"github.com/mitchellh/mapstructure"
@@ -13,11 +14,12 @@ type DefaultConfig struct {
 	GenCode GenCodeConfig `yaml:"genCode"`
 }
 
-// ReadConfig reads from a single config file and populates both custom, library and genCode config structs
-// cfgFile: path to config file
-// config: a pointer to the custom config struct
-func ReadConfig(cfgFile string, defaultConfig *DefaultConfig, customConfig interface{}) error {
-	b, err := ioutil.ReadFile(cfgFile)
+// LoadConfig reads and validates a configuration loaded from file.
+// file: the path to the yaml-encoded config file
+// defaultConfig: a pointer to the default config struct to populate
+// customConfig: a pointer to the custom config struct to populate
+func LoadConfig(file string, defaultConfig *DefaultConfig, customConfig interface{}) error {
+	b, err := ioutil.ReadFile(file)
 	if err != nil {
 		return fmt.Errorf("read config file error: %s", err)
 	}
@@ -40,5 +42,20 @@ func ReadConfig(cfgFile string, defaultConfig *DefaultConfig, customConfig inter
 		return err
 	}
 
-	return decoder.Decode(c)
+	err = decoder.Decode(c)
+	if err != nil {
+		return err
+	}
+
+	err = validator.Validate(defaultConfig)
+	if err != nil {
+		return err
+	}
+
+	err = validator.Validate(customConfig)
+	if err != nil {
+		return err
+	}
+
+	return err
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"gopkg.in/go-playground/validator.v9"
 	"testing"
 	"time"
 
@@ -33,17 +34,21 @@ type TestDownstreamConfig struct {
 	Bar            CommonDownstreamData `yaml:"bar"`
 }
 
-func TestSReadConfig(t *testing.T) {
-	t.Parallel()
-
-	defaultConfig := DefaultConfig{
+func testDefaultConfig() DefaultConfig {
+	return DefaultConfig{
 		Library: LibraryConfig{},
 		GenCode: GenCodeConfig{
 			Downstream: &TestDownstreamConfig{},
 		},
 	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	t.Parallel()
+
+	defaultConfig := testDefaultConfig()
 	myConfig := TestMyConfig{}
-	err := ReadConfig("testdata/config.yaml", &defaultConfig, &myConfig)
+	err := LoadConfig("testdata/config.yaml", &defaultConfig, &myConfig)
 
 	require.Nil(t, err)
 
@@ -55,6 +60,17 @@ func TestSReadConfig(t *testing.T) {
 
 	require.Equal(t, 8080, defaultConfig.GenCode.Upstream.HTTP.Common.Port)
 	require.Equal(t, 8081, defaultConfig.GenCode.Upstream.GRPC.Port)
-	require.Equal(t, 120*time.Second, defaultConfig.GenCode.Downstream.(*TestDownstreamConfig).Foo.ClientTimeout)
+	require.Equal(t, 10*time.Second, defaultConfig.GenCode.Downstream.(*TestDownstreamConfig).Foo.ClientTimeout)
 	require.Equal(t, "https://bar.example.com", defaultConfig.GenCode.Downstream.(*TestDownstreamConfig).Bar.ServiceURL)
+}
+
+func TestLoadInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	defaultConfig := testDefaultConfig()
+	myConfig := TestMyConfig{}
+	err := LoadConfig("testdata/config_invalid.yaml", &defaultConfig, &myConfig)
+
+	_, ok := err.(validator.ValidationErrors)
+	require.True(t, ok)
 }

--- a/config/testdata/config_invalid.yaml
+++ b/config/testdata/config_invalid.yaml
@@ -31,7 +31,7 @@ genCode:
     contextTimeout: 120s
     foo:
       serviceURL: https://foo.example.com
-      clientTimeout: 10s
+      clientTimeout: 120s # invalid. too large
     bar:
       serviceURL: https://bar.example.com
       clientTimeout: 10s


### PR DESCRIPTION
The config.ReadConfig method reads configuration from file and
populates passed-in config structs. To ensure that the returned
configuration is valid the method now validates the loaded
configuration before returning.

To avoid ambiguity and provide only a single mechanism to load
configuration, this method has been renamed to LoadConfig.