### PR TITLE
Allow endpoints to return sequences, Fix build.

### DIFF
--- a/codegen/testdata/simple/simple.sysl
+++ b/codegen/testdata/simple/simple.sysl
@@ -29,7 +29,7 @@ Simple "Simple Server" [package="simple"]:
         GET:
             Deps <- GET /api-docs
             Downstream <- GET /service-docs
-            return ok <: Deps.ApiDoc
+            return ok <: sequence of Deps.ApiDoc
 
     /simple-api-docs:
         GET:

--- a/codegen/tests/simple/service.go
+++ b/codegen/tests/simple/service.go
@@ -15,14 +15,16 @@ import (
 
 // Service interface for Simple
 type Service interface {
+	GetApiDocsList(ctx context.Context, req *GetApiDocsListRequest) (*[]deps.ApiDoc, error)
+	GetGetSomeBytesList(ctx context.Context, req *GetGetSomeBytesListRequest) (*Pdf, error)
 	GetJustOkAndJustErrorList(ctx context.Context, req *GetJustOkAndJustErrorListRequest) (*http.Header, error)
 	GetJustReturnErrorList(ctx context.Context, req *GetJustReturnErrorListRequest) error
 	GetJustReturnOkList(ctx context.Context, req *GetJustReturnOkListRequest) (*http.Header, error)
 	GetOkTypeAndJustErrorList(ctx context.Context, req *GetOkTypeAndJustErrorListRequest) (*Response, error)
-	GetApiDocsList(ctx context.Context, req *GetApiDocsListRequest) (*deps.ApiDoc, error)
 	GetOopsList(ctx context.Context, req *GetOopsListRequest) (*Response, error)
 	GetRawList(ctx context.Context, req *GetRawListRequest) (*Str, error)
 	GetRawIntList(ctx context.Context, req *GetRawIntListRequest) (*Integer, error)
+	GetSimpleAPIDocsList(ctx context.Context, req *GetSimpleAPIDocsListRequest) (*deps.ApiDoc, error)
 	GetStuffList(ctx context.Context, req *GetStuffListRequest) (*Stuff, error)
 	PostStuff(ctx context.Context, req *PostStuffRequest) (*Str, error)
 }
@@ -36,6 +38,70 @@ type Client struct {
 // NewClient for Simple
 func NewClient(client *http.Client, serviceURL string) *Client {
 	return &Client{client, serviceURL}
+}
+
+// GetApiDocsList ...
+func (s *Client) GetApiDocsList(ctx context.Context, req *GetApiDocsListRequest) (*[]deps.ApiDoc, error) {
+	required := []string{}
+	var okResponse []deps.ApiDoc
+
+	u, err := url.Parse(fmt.Sprintf("%s/api-docs", s.url))
+	if err != nil {
+		return nil, common.CreateError(ctx, common.InternalError, "failed to parse url", err)
+	}
+
+	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	if err != nil {
+		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
+	}
+
+	if result.HTTPResponse.StatusCode == http.StatusUnauthorized {
+		return nil, common.CreateDownstreamError(ctx, common.DownstreamUnauthorizedError, result.HTTPResponse, result.Body, nil)
+	}
+
+	OkDepsApiDocResponse, ok := result.Response.(*[]deps.ApiDoc)
+	if ok {
+		valErr := validator.Validate(OkDepsApiDocResponse)
+		if valErr != nil {
+			return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, valErr)
+		}
+
+		return OkDepsApiDocResponse, nil
+	}
+
+	return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, nil)
+}
+
+// GetGetSomeBytesList ...
+func (s *Client) GetGetSomeBytesList(ctx context.Context, req *GetGetSomeBytesListRequest) (*Pdf, error) {
+	required := []string{}
+	var okResponse Pdf
+
+	u, err := url.Parse(fmt.Sprintf("%s/get-some-bytes", s.url))
+	if err != nil {
+		return nil, common.CreateError(ctx, common.InternalError, "failed to parse url", err)
+	}
+
+	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	if err != nil {
+		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
+	}
+
+	if result.HTTPResponse.StatusCode == http.StatusUnauthorized {
+		return nil, common.CreateDownstreamError(ctx, common.DownstreamUnauthorizedError, result.HTTPResponse, result.Body, nil)
+	}
+
+	OkPdfResponse, ok := result.Response.(*Pdf)
+	if ok {
+		valErr := validator.Validate(OkPdfResponse)
+		if valErr != nil {
+			return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, valErr)
+		}
+
+		return OkPdfResponse, nil
+	}
+
+	return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, nil)
 }
 
 // GetJustOkAndJustErrorList ...
@@ -125,38 +191,6 @@ func (s *Client) GetOkTypeAndJustErrorList(ctx context.Context, req *GetOkTypeAn
 		}
 
 		return OkResponseResponse, nil
-	}
-
-	return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, nil)
-}
-
-// GetApiDocsList ...
-func (s *Client) GetApiDocsList(ctx context.Context, req *GetApiDocsListRequest) (*deps.ApiDoc, error) {
-	required := []string{}
-	var okResponse deps.ApiDoc
-
-	u, err := url.Parse(fmt.Sprintf("%s/api-docs", s.url))
-	if err != nil {
-		return nil, common.CreateError(ctx, common.InternalError, "failed to parse url", err)
-	}
-
-	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
-	if err != nil {
-		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
-	}
-
-	if result.HTTPResponse.StatusCode == http.StatusUnauthorized {
-		return nil, common.CreateDownstreamError(ctx, common.DownstreamUnauthorizedError, result.HTTPResponse, result.Body, nil)
-	}
-
-	OkDepsApiDocResponse, ok := result.Response.(*deps.ApiDoc)
-	if ok {
-		valErr := validator.Validate(OkDepsApiDocResponse)
-		if valErr != nil {
-			return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, valErr)
-		}
-
-		return OkDepsApiDocResponse, nil
 	}
 
 	return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, nil)
@@ -260,6 +294,38 @@ func (s *Client) GetRawIntList(ctx context.Context, req *GetRawIntListRequest) (
 		}
 
 		return OkIntegerResponse, nil
+	}
+
+	return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, nil)
+}
+
+// GetSimpleAPIDocsList ...
+func (s *Client) GetSimpleAPIDocsList(ctx context.Context, req *GetSimpleAPIDocsListRequest) (*deps.ApiDoc, error) {
+	required := []string{}
+	var okResponse deps.ApiDoc
+
+	u, err := url.Parse(fmt.Sprintf("%s/simple-api-docs", s.url))
+	if err != nil {
+		return nil, common.CreateError(ctx, common.InternalError, "failed to parse url", err)
+	}
+
+	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	if err != nil {
+		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
+	}
+
+	if result.HTTPResponse.StatusCode == http.StatusUnauthorized {
+		return nil, common.CreateDownstreamError(ctx, common.DownstreamUnauthorizedError, result.HTTPResponse, result.Body, nil)
+	}
+
+	OkDepsApiDocResponse, ok := result.Response.(*deps.ApiDoc)
+	if ok {
+		valErr := validator.Validate(OkDepsApiDocResponse)
+		if valErr != nil {
+			return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, valErr)
+		}
+
+		return OkDepsApiDocResponse, nil
 	}
 
 	return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, nil)

--- a/codegen/tests/simple/serviceinterface.go
+++ b/codegen/tests/simple/serviceinterface.go
@@ -72,7 +72,7 @@ type PostStuffClient struct {
 
 // ServiceInterface for Simple
 type ServiceInterface struct {
-	GetApiDocsList            func(ctx context.Context, req *GetApiDocsListRequest, client GetApiDocsListClient) (*deps.ApiDoc, error)
+	GetApiDocsList            func(ctx context.Context, req *GetApiDocsListRequest, client GetApiDocsListClient) (*[]deps.ApiDoc, error)
 	GetGetSomeBytesList       func(ctx context.Context, req *GetGetSomeBytesListRequest, client GetGetSomeBytesListClient) (*Pdf, error)
 	GetJustOkAndJustErrorList func(ctx context.Context, req *GetJustOkAndJustErrorListRequest, client GetJustOkAndJustErrorListClient) error
 	GetJustReturnErrorList    func(ctx context.Context, req *GetJustReturnErrorListRequest, client GetJustReturnErrorListClient) error

--- a/codegen/tests/simple/simple_test.go
+++ b/codegen/tests/simple/simple_test.go
@@ -610,3 +610,23 @@ func TestAppInitialiseHandlers(t *testing.T) {
 	reflect.DeepEqual(testCallback, srvRouter.svcHandler.genCallback)
 	reflect.DeepEqual(testServiceInterface, srvRouter.svcHandler.serviceInterface)
 }
+
+func TestApiDocsReturnsSequence(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		depsSeq := `[{"openapi":"1","swagger":"2"},{"openapi":"y","swagger":"n"}]`
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(depsSeq))
+	}))
+	client := server.Client()
+	defer server.Close()
+
+	c := Client{
+		client: client,
+		url:    server.URL,
+	}
+
+	req := GetApiDocsListRequest{}
+	sequenceRes, err := c.GetApiDocsList(context.Background(), &req)
+	require.NoError(t, err)
+	require.True(t, len(*sequenceRes) > 0)
+}

--- a/codegen/transforms/svc_client.sysl
+++ b/codegen/transforms/svc_client.sysl
@@ -229,7 +229,7 @@ CodeGenTransform:
       )
     )
 
-  !view castResult(ret <: sysl.Ret) -> StatementList:
+  !view castResult(ret <: sysl.Ret, module <: sysl.Module) -> StatementList:
     ret -> (:
       let name = makeType(ret.value)
 
@@ -237,7 +237,7 @@ CodeGenTransform:
         DeclareAndAssignStmt = ret -> <DeclareAndAssignStmt> (:
           Variables = GoName(ret.key).out + name.varName + 'Response, ok'
           Expression = ret -> <Expression> (:
-            ValueExpr = "result.Response.(*" + name.typeName + ")"
+            ValueExpr = "result.Response.(*" + makeTypeWithClientPackage(Replace(ret.value, getClientPackage(ret.value, module).prefix, "", -1), getClientPackage(ret.value, module).package).out + ")"
           )
         )
       )
@@ -291,20 +291,20 @@ CodeGenTransform:
       )
     )
 
-  !view castResults(ep <: sysl.Endpoint) -> Block:
+  !view castResults(ep <: sysl.Endpoint, module <: sysl.Module) -> Block:
     ep -> (:
       let casting = ep.value.ret where (.key != "error" && .value != "ok" && .value != "error") -> <sequence of string> (rt:
-        out = [castResult(rt), returnCastResult(rt, ep)]
+        out = [castResult(rt, module), returnCastResult(rt, ep)]
       )
       let test = casting flatten(.out)
       StatementList = test flatten(.)
     )
 
-  !view declareResponseAsNil(ret <: sysl.Ret) -> Statement:
+  !view declareResponseAsNil(ret <: sysl.Ret, module <: sysl.Module) -> Statement:
     ret -> (:
       VarDecl = ret -> <VarDecl> (:
         identifier = GoName(ret.key).out + makeType(ret.value).varName + "Response"
-        TypeName = "*" + makeType(ret.value).typeName
+        TypeName = makeTypeWithClientPackage(Replace(ret.value, getClientPackage(ret.value, module).prefix, "", -1), getClientPackage(ret.value, module).package).out
       )
     )
 
@@ -356,22 +356,22 @@ CodeGenTransform:
       )
     )
 
-  !view declareResp(varName <: string, ep <: sysl.Endpoint) -> Block:
+  !view declareResp(varName <: string, ep <: sysl.Endpoint, module <: sysl.Module) -> Block:
     ep -> (:
       StatementList = ep.value.ret where(.key == varName) -> <sequence of StatementList>(d:
         Statement = d -> <Statement> (:
           VarDecl = d -> <VarDecl> (:
             identifier = varName + "Response"
-            TypeName = makeType(d.value).typeName
+            TypeName = makeTypeWithClientPackage(Replace(d.value, getClientPackage(d.value, module).prefix, "", -1), getClientPackage(d.value, module).package).out
           )
         )
       )
     )
 
-  !view declareReturnTypeArray(ep <: sysl.Endpoint) -> Block:
+  !view declareReturnTypeArray(ep <: sysl.Endpoint, module <: sysl.Module) -> Block:
     ep -> (:
-      let okDecl = declareResp("ok", ep).StatementList
-      let errorDecl = declareResp("error", ep).StatementList
+      let okDecl = declareResp("ok", ep, module).StatementList
+      let errorDecl = declareResp("error", ep, module).StatementList
 
       StatementList =  okDecl | errorDecl
     )
@@ -517,7 +517,7 @@ CodeGenTransform:
       out = if resultTypes flatten(.typeName) count > 0 then Join(resultTypes flatten(.typeName),", ") + ", " else ""
     )
 
-  !view HttpMethodStatments(appName <: string, ep <: sysl.Endpoint) -> Block:
+  !view HttpMethodStatments(appName <: string, ep <: sysl.Endpoint, module <: sysl.Module) -> Block:
     ep -> (:
       let requiredHeaders = ep.value.params where("header" in .attrs.patterns && "required" in .attrs.patterns)
       let required = declareHeaders("required", "string", requiredHeaders flatten(.attrs.name))
@@ -528,15 +528,15 @@ CodeGenTransform:
         out = t.value
       )
 
-      let responses = declareReturnTypeArray(ep).StatementList
+      let responses = declareReturnTypeArray(ep, module).StatementList
       let retIfErr = returnIfError("err != nil", emptyStatements("").StatementList,  nilResponseGenerator(ep).out + 'common.CreateError(ctx, common.InternalError, "failed to parse url", err)')
       let stmts =  [required] | responses | [urlVariable(ep), retIfErr]
       StatementList = if ep.value.queryvars count ==:
-       0 => stmts | [callRestLib(ep), callRestLibCheck(appName, ep), castErrorCodeCheck(ep)] | castResults(ep).StatementList | [castFallThroughCheck(ep)]
-       else stmts | [declareQueryVar("q")] | addQueryParams(ep) | addOptionalQueryParams(ep) | [updateRawQuery("") , callRestLib(ep), callRestLibCheck(appName, ep), castErrorCodeCheck(ep)] | castResults(ep).StatementList | [castFallThroughCheck(ep)]
+       0 => stmts | [callRestLib(ep), callRestLibCheck(appName, ep), castErrorCodeCheck(ep)] | castResults(ep, module).StatementList | [castFallThroughCheck(ep)]
+       else stmts | [declareQueryVar("q")] | addQueryParams(ep) | addOptionalQueryParams(ep) | [updateRawQuery("") , callRestLib(ep), callRestLibCheck(appName, ep), castErrorCodeCheck(ep)] | castResults(ep, module).StatementList | [castFallThroughCheck(ep)]
     )
 
-  !view ClientMethods(appName <: string, eps <: set of sysl.Endpoints) -> sequence of TopLevelDecl:
+  !view ClientMethods(appName <: string, eps <: set of sysl.Endpoints, module <: sysl.Module) -> sequence of TopLevelDecl:
     eps -> (ep:
       let funcName = methodName(ep.value.method, ep.value.path).out
       Comment = '// ' + funcName + ' ...'
@@ -545,8 +545,8 @@ CodeGenTransform:
           ReceiverType = "s *Client"
         )
         FunctionName = funcName
-        Signature = methodSignature(ep)
-        Block = HttpMethodStatments(appName, ep)
+        Signature = methodSignature(ep, module)
+        Block = HttpMethodStatments(appName, ep, module)
       )
     )
 
@@ -569,17 +569,39 @@ CodeGenTransform:
       varName = TrimPrefix(safeType, "[]")
     )
 
-  !view makeResult(ep <: sysl.Endpoint) -> Result:
+  !view makeTypeWithClientPackage(input <: string, package <: string) -> string:
+    input -> (:
+      let pkgString = if package == "" then "" else package + "."
+      let userType = if HasPrefix(input, "sequence of") then "[]" + pkgString + GoName(TrimPrefix(input, "sequence of ")).out else pkgString + GoName(input).out
+      out = if input in ["error"] then input else userType
+    )  
+
+  !view getClientPackage(input <: string, module <: sysl.Module) -> string:
+    input -> (:
+      let packages = Split(input, ".") -> <set of string>(p:
+        let app = if HasPrefix(p, "sequence of") then TrimPrefix(p, "sequence of ") else p
+        let depList = module.apps where(.value.name == app) -> <set of string> (dep:
+          pkg = getPackage(dep.value).pname
+          prefix = app
+        )
+        pkg = depList flatten(.pkg)
+        prefix = depList flatten(.prefix)
+      )
+      prefix = if packages flatten(.prefix) count == 0 then "" else packages flatten(.prefix) single + "."
+      package = if packages flatten(.pkg) count == 0 then "" else packages flatten(.pkg) single
+    )
+  
+  !view makeResult(ep <: sysl.Endpoint, module <: sysl.Module) -> Result:
     ep -> (:
       ReturnTypes = ep -> <ReturnTypes>(:
         let tn = ep.value.ret where (.key != "error" && .value != "error") -> <sequence of string>(t:
-          out = if t.value == "ok" then "*http.Header" else "*" + makeType(t.value).out
+          out = if t.value == "ok" then "*http.Header" else "*" + makeTypeWithClientPackage(Replace(t.value, getClientPackage(t.value, module).prefix, "", -1), getClientPackage(t.value, module).package).out
         )
         TypeName = Join(tn flatten(.out) | ["error"], ", ")
       )
     )
 
-  !view methodSignature(ep <: sysl.Endpoint) -> Signature:
+  !view methodSignature(ep <: sysl.Endpoint, module <: sysl.Module) -> Signature:
     ep -> (:
       Parameters = ep -> <Parameters>(:
         ParameterList = ep -> <ParameterList>(:
@@ -600,13 +622,13 @@ CodeGenTransform:
           )
         )
       )
-      Result = makeResult(ep)
+      Result = makeResult(ep, module)
     )
 
-  !view GoMethods(eps <: set of sysl.Endpoints) -> sequence of MethodSpec:
+  !view GoMethods(eps <: set of sysl.Endpoints, module <: sysl.Module) -> sequence of MethodSpec:
     eps -> (ep:
       MethodName = methodName(ep.value.method, ep.value.path).out
-      Signature = methodSignature(ep)
+      Signature = methodSignature(ep, module)
     )
 
   !view varDecl(name <: string, typeName <: string) -> TopLevelDecl:
@@ -620,7 +642,7 @@ CodeGenTransform:
       )
     )
 
-  !view goFile(app <: sysl.App) -> goFile:
+  !view goFile(app <: sysl.App, module <: sysl.Module) -> goFile:
     app -> (:
 
       PackageClause = app -> <package> (:
@@ -644,7 +666,7 @@ CodeGenTransform:
         Declaration = title -> <Declaration>(:
           InterfaceType = title -> <InterfaceType>(:
             InterfaceName = title
-            MethodSpec =  GoMethods(app.endpoints)
+            MethodSpec =  GoMethods(app.endpoints, module)
           )
         )
       )
@@ -713,7 +735,7 @@ CodeGenTransform:
       )
       Comment = "// Code generated by sysl DO NOT EDIT.\n"
 
-      TopLevelDecl = GoInterfaces(app.union) | svcInterface | clientStruct |  makeClient  |  ClientMethods(.name, app.endpoints)
+      TopLevelDecl = GoInterfaces(app.union) | svcInterface | clientStruct |  makeClient  |  ClientMethods(.name, app.endpoints, module)
     )
 
   !view getPackage(app <: sysl.App) -> string:

--- a/codegen/transforms/svc_interface.sysl
+++ b/codegen/transforms/svc_interface.sysl
@@ -102,9 +102,10 @@ CodeGenTransform:
       ReturnTypes = ep -> <ReturnTypes>(:
         let tn = ep.value.ret where (.key != "error" && .value != "ok") -> <set of string>(t:
           let packages = Split(t.value, ".") -> <set of string>(p:
-            let depList = module.apps where(.value.name == p) -> <set of string> (dep:
+            let app = if HasPrefix(p, "sequence of") then TrimPrefix(p, "sequence of ") else p
+            let depList = module.apps where(.value.name == app) -> <set of string> (dep:
               pkg = getPackage(dep.value).pname
-              prefix = p
+              prefix = app
             )
             pkg = depList flatten(.pkg)
             prefix = depList flatten(.prefix)
@@ -112,8 +113,7 @@ CodeGenTransform:
           let prefix = if packages flatten(.prefix) count == 0 then "" else packages flatten(.prefix) single + "."
           let package = if packages flatten(.pkg) count == 0 then "" else packages flatten(.pkg) single
 
-          out = makeType(TrimPrefix(t.value,prefix), package).out
-
+          out = makeType(Replace(t.value, prefix, "", -1), package).out
         )
         TypeName = Join(tn flatten(.out)  | {"error"}, ", ")
       )

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -73,7 +73,8 @@ func Validate(v interface{}) error {
 	}
 	val := reflect.ValueOf(v)
 	if val.Kind() == reflect.Ptr && !val.IsNil() {
-		if val = val.Elem(); val.Kind() == reflect.String {
+		switch val.Elem().Kind() {
+		case reflect.String, reflect.Slice:
 			return nil
 		}
 	}


### PR DESCRIPTION
Fixes codegen to correctly generate code when the endpoints return sequences.


Closes: #76 and #74 
