### PR TITLE
Move ReadConfig to LoadConfig and validate

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/go-playground/validator.v9"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -33,17 +35,21 @@ type TestDownstreamConfig struct {
 	Bar            CommonDownstreamData `yaml:"bar"`
 }
 
-func TestSReadConfig(t *testing.T) {
-	t.Parallel()
-
-	defaultConfig := DefaultConfig{
+func testDefaultConfig() DefaultConfig {
+	return DefaultConfig{
 		Library: LibraryConfig{},
 		GenCode: GenCodeConfig{
 			Downstream: &TestDownstreamConfig{},
 		},
 	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	t.Parallel()
+
+	defaultConfig := testDefaultConfig()
 	myConfig := TestMyConfig{}
-	err := ReadConfig("testdata/config.yaml", &defaultConfig, &myConfig)
+	err := LoadConfig("testdata/config.yaml", &defaultConfig, &myConfig)
 
 	require.Nil(t, err)
 
@@ -55,6 +61,17 @@ func TestSReadConfig(t *testing.T) {
 
 	require.Equal(t, 8080, defaultConfig.GenCode.Upstream.HTTP.Common.Port)
 	require.Equal(t, 8081, defaultConfig.GenCode.Upstream.GRPC.Port)
-	require.Equal(t, 120*time.Second, defaultConfig.GenCode.Downstream.(*TestDownstreamConfig).Foo.ClientTimeout)
+	require.Equal(t, 10*time.Second, defaultConfig.GenCode.Downstream.(*TestDownstreamConfig).Foo.ClientTimeout)
 	require.Equal(t, "https://bar.example.com", defaultConfig.GenCode.Downstream.(*TestDownstreamConfig).Bar.ServiceURL)
+}
+
+func TestLoadInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	defaultConfig := testDefaultConfig()
+	myConfig := TestMyConfig{}
+	err := LoadConfig("testdata/config_invalid.yaml", &defaultConfig, &myConfig)
+
+	_, ok := err.(validator.ValidationErrors)
+	require.True(t, ok)
 }

--- a/config/testdata/config_invalid.yaml
+++ b/config/testdata/config_invalid.yaml
@@ -31,7 +31,7 @@ genCode:
     contextTimeout: 120s
     foo:
       serviceURL: https://foo.example.com
-      clientTimeout: 10s
+      clientTimeout: 120s # invalid. too large
     bar:
       serviceURL: https://bar.example.com
       clientTimeout: 10s


### PR DESCRIPTION
The config.ReadConfig method reads configuration from file and
populates passed-in config structs. To ensure that the returned
configuration is valid the method now validates the loaded
configuration before returning.

To avoid ambiguity and provide only a single mechanism to load
configuration, this method has been renamed to LoadConfig.