### PR TITLE
Add more http statuses to success criteria.

### DIFF
--- a/codegen/tests/simple/simple_test.go
+++ b/codegen/tests/simple/simple_test.go
@@ -553,6 +553,13 @@ func TestJustOKAndJustErrorReturnsHeadersWhenOK(t *testing.T) {
 	require.Equal(t, `{"jsonField":"jsonVal"}`, h.Get("Context"))
 }
 
+func Test204OKResponse(t *testing.T) {
+	c, s := bodylessClientServer(204)
+	defer s.Close()
+	_, err := c.GetJustOkAndJustErrorList(context.Background(), &GetJustOkAndJustErrorListRequest{})
+	require.NoError(t, err)
+}
+
 func TestJustOKAndJustErrorPutsHeadersInErrorWhenError(t *testing.T) {
 	c, s := bodylessClientServer(400)
 	defer s.Close()

--- a/restlib/restlib_test.go
+++ b/restlib/restlib_test.go
@@ -38,6 +38,15 @@ func Test_unmarshalNilBodyOK(t *testing.T) {
 	require.Nil(t, result.Response)
 }
 
+func Test_unmarshalPointerBodyOK(t *testing.T) {
+	result, err := unmarshal(&http.Response{}, nil, &OkType{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.HTTPResponse)
+	require.Nil(t, result.Body)
+	require.NotNil(t, result.Response)
+}
+
 func Test_unmarshalEmptyBodyOK(t *testing.T) {
 	result, err := unmarshal(&http.Response{}, make([]byte, 0), OkType{})
 	require.NoError(t, err)
@@ -76,6 +85,19 @@ func Test_DoHTTPRequestOkType(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(okJSON))
+	}))
+	defer srv.Close()
+
+	result, err := DoHTTPRequest(context.Background(), srv.Client(), "GET", srv.URL, nil, make([]string, 0), &OkType{}, &ErrorType{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.IsType(t, &OkType{}, result.Response)
+}
+
+func Test_DoHTTPRequest204Response(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+		_, _ = w.Write(nil)
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
Add more http statuses in the success criteria, it includes only http.StatusOK, http.StatusCreated and
http.StatusAccepted for now.

1. Add more http statuses in the success criteria.
2. Fix code to send back an empty response, if the downstream returns a nil response.

Closes #80 