### PR TITLE
Remove necessity for `GenCallback.Config` to be a `Validator.

### DIFF
--- a/codegen/tests/dbendpoints/dbendpoints_gencallback.go
+++ b/codegen/tests/dbendpoints/dbendpoints_gencallback.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/anz-bank/sysl-go/common"
 
-	"github.com/anz-bank/sysl-go/validator"
-
 	"github.com/go-chi/chi"
 )
 
@@ -25,7 +23,7 @@ func (c Callback) DownstreamTimeoutContext(ctx context.Context) (context.Context
 	return context.WithTimeout(ctx, 1*time.Second)
 }
 
-func (c Callback) Config() validator.Validator {
+func (c Callback) Config() interface{} {
 	return Config{}
 }
 

--- a/codegen/tests/dbendpoints/requestrouter.go
+++ b/codegen/tests/dbendpoints/requestrouter.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/anz-bank/sysl-go/core"
 	"github.com/anz-bank/sysl-go/handlerinitialiser"
-	"github.com/anz-bank/sysl-go/validator"
 	"github.com/go-chi/chi"
 )
 
@@ -46,7 +45,7 @@ func (s *ServiceRouter) WireRoutes(ctx context.Context, r chi.Router) {
 }
 
 // Config ...
-func (s *ServiceRouter) Config() validator.Validator {
+func (s *ServiceRouter) Config() interface{} {
 	return s.gc.Config()
 }
 

--- a/codegen/tests/deps/requestrouter.go
+++ b/codegen/tests/deps/requestrouter.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/anz-bank/sysl-go/core"
 	"github.com/anz-bank/sysl-go/handlerinitialiser"
-	"github.com/anz-bank/sysl-go/validator"
 	"github.com/go-chi/chi"
 )
 
@@ -46,7 +45,7 @@ func (s *ServiceRouter) WireRoutes(ctx context.Context, r chi.Router) {
 }
 
 // Config ...
-func (s *ServiceRouter) Config() validator.Validator {
+func (s *ServiceRouter) Config() interface{} {
 	return s.gc.Config()
 }
 

--- a/codegen/tests/downstream/requestrouter.go
+++ b/codegen/tests/downstream/requestrouter.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/anz-bank/sysl-go/core"
 	"github.com/anz-bank/sysl-go/handlerinitialiser"
-	"github.com/anz-bank/sysl-go/validator"
 	"github.com/go-chi/chi"
 )
 
@@ -46,7 +45,7 @@ func (s *ServiceRouter) WireRoutes(ctx context.Context, r chi.Router) {
 }
 
 // Config ...
-func (s *ServiceRouter) Config() validator.Validator {
+func (s *ServiceRouter) Config() interface{} {
 	return s.gc.Config()
 }
 

--- a/codegen/tests/simple/requestrouter.go
+++ b/codegen/tests/simple/requestrouter.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/anz-bank/sysl-go/core"
 	"github.com/anz-bank/sysl-go/handlerinitialiser"
-	"github.com/anz-bank/sysl-go/validator"
 	"github.com/go-chi/chi"
 )
 
@@ -57,7 +56,7 @@ func (s *ServiceRouter) WireRoutes(ctx context.Context, r chi.Router) {
 }
 
 // Config ...
-func (s *ServiceRouter) Config() validator.Validator {
+func (s *ServiceRouter) Config() interface{} {
 	return s.gc.Config()
 }
 

--- a/codegen/tests/simple/simple_gencallback.go
+++ b/codegen/tests/simple/simple_gencallback.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/anz-bank/sysl-go/common"
 
-	"github.com/anz-bank/sysl-go/validator"
-
 	"github.com/go-chi/chi"
 )
 
@@ -25,7 +23,7 @@ func (c Callback) DownstreamTimeoutContext(ctx context.Context) (context.Context
 	return context.WithTimeout(ctx, 1*time.Second)
 }
 
-func (c Callback) Config() validator.Validator {
+func (c Callback) Config() interface{} {
 	return Config{}
 }
 

--- a/codegen/transforms/svc_router.sysl
+++ b/codegen/transforms/svc_router.sysl
@@ -93,9 +93,8 @@ CodeGenTransform:
         let hiImport = "github.com/anz-bank/sysl-go/handlerinitialiser"
         let bffCommonImport = "github.com/anz-bank/sysl-go/common"
         let coreImport = "github.com/anz-bank/sysl-go/core"
-        let validatorImport = "github.com/anz-bank/sysl-go/validator"
 
-        let spec = ["context", "net/http", "github.com/go-chi/chi", hiImport, bffCommonImport, coreImport, validatorImport] -> <sequence of ImportSpec> (importPath:
+        let spec = ["context", "net/http", "github.com/go-chi/chi", hiImport, bffCommonImport, coreImport] -> <sequence of ImportSpec> (importPath:
           Import = if importPath == "" then true else '"' + importPath + '"'
         )
         ImportSpec = spec
@@ -322,7 +321,7 @@ CodeGenTransform:
           Signature = name -> <Signature> (:
             Parameters = true
             Result = name -> <Result>(:
-              TypeName = "validator.Validator"
+              TypeName = "interface{}"
             )
           )
           Block = name -> <Block>(:

--- a/common/defaultcallback.go
+++ b/common/defaultcallback.go
@@ -38,7 +38,7 @@ func (g Callback) BasePath() string {
 	return g.RouterBasePath
 }
 
-func (g Callback) Config() validator.Validator {
+func (g Callback) Config() interface{} {
 	return g.UpstreamConfig
 }
 

--- a/core/callback.go
+++ b/core/callback.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/anz-bank/sysl-go/common"
-	"github.com/anz-bank/sysl-go/validator"
 	"github.com/go-chi/chi"
 )
 
@@ -16,7 +15,7 @@ type RestGenCallback interface {
 	BasePath() string
 	// Config returns a structure representing the server config
 	// This is returned from the status endpoint
-	Config() validator.Validator
+	Config() interface{}
 	// MapError maps an error to an HTTPError in instances where custom error mapping is required. Return nil to perform default error mapping; defined as:
 	// 1. CustomError.HTTPError if the original error is a CustomError, otherwise
 	// 2. common.MapError

--- a/handlerinitialiser/handlerinitialiser.go
+++ b/handlerinitialiser/handlerinitialiser.go
@@ -3,7 +3,6 @@ package handlerinitialiser
 import (
 	"context"
 
-	"github.com/anz-bank/sysl-go/validator"
 	"github.com/go-chi/chi"
 	"google.golang.org/grpc"
 )
@@ -11,7 +10,7 @@ import (
 type HandlerInitialiser interface {
 	WireRoutes(ctx context.Context, r chi.Router)
 	Name() string                // Human-friendly name of the service
-	Config() validator.Validator // Reference to config for this service.
+	Config() interface{} // Reference to config for this service.
 }
 
 type GrpcHandlerInitialiser interface {

--- a/handlerinitialiser/handlerinitialiser.go
+++ b/handlerinitialiser/handlerinitialiser.go
@@ -9,7 +9,7 @@ import (
 
 type HandlerInitialiser interface {
 	WireRoutes(ctx context.Context, r chi.Router)
-	Name() string                // Human-friendly name of the service
+	Name() string        // Human-friendly name of the service
 	Config() interface{} // Reference to config for this service.
 }
 


### PR DESCRIPTION
This change removes the necessity for config to be a validator. The current declaration of config instances within sysl-go have a requirement that they are validator.Validator instances. Internally,
sysl-go only uses the config to attach to the response for a request of the configuration (which doesn't require it to be a Validator).

1. Fix RestGenCallback interface.
2. Fix requestrouter.go and requestrouter.sysl.

Closes #82 