### PR TITLE
Fix downstream to handle return <: ok.

### DIFF
--- a/codegen/testdata/simple/deps.sysl
+++ b/codegen/testdata/simple/deps.sysl
@@ -7,6 +7,10 @@ Deps "Downstream Server" [package="deps"]:
             return ok <: ApiDoc
             return error <: status
 
+    /success:
+        GET:
+            return ok
+
     !type ApiDoc:
         swagger <: string:
             @json_tag = "swagger"

--- a/codegen/testdata/simple/simple.sysl
+++ b/codegen/testdata/simple/simple.sysl
@@ -34,6 +34,7 @@ Simple "Simple Server" [package="simple"]:
     /simple-api-docs:
         GET:
             Deps <- GET /api-docs
+            Deps <- GET /success
             return ok <: Deps.ApiDoc
 
     # /no-return-type:

--- a/codegen/tests/deps/serviceinterface.go
+++ b/codegen/tests/deps/serviceinterface.go
@@ -19,9 +19,14 @@ func NewDefaultDepsImpl() *DefaultDepsImpl {
 type GetApiDocsListClient struct {
 }
 
+// GetSuccessList Client
+type GetSuccessListClient struct {
+}
+
 // ServiceInterface for Deps
 type ServiceInterface struct {
 	GetApiDocsList func(ctx context.Context, req *GetApiDocsListRequest, client GetApiDocsListClient) (*ApiDoc, error)
+	GetSuccessList func(ctx context.Context, req *GetSuccessListRequest, client GetSuccessListClient) error
 }
 
 // DownstreamConfig for Deps

--- a/codegen/tests/deps/types.go
+++ b/codegen/tests/deps/types.go
@@ -29,6 +29,10 @@ type Status struct {
 type GetApiDocsListRequest struct {
 }
 
+// GetSuccessListRequest ...
+type GetSuccessListRequest struct {
+}
+
 // *ApiDoc validator
 func (s *ApiDoc) Validate() error {
 	return validator.Validate(s)

--- a/codegen/tests/simple/servicehandler.go
+++ b/codegen/tests/simple/servicehandler.go
@@ -361,6 +361,7 @@ func (s *ServiceHandler) GetSimpleAPIDocsListHandler(w http.ResponseWriter, r *h
 
 	client := GetSimpleAPIDocsListClient{
 		GetApiDocsList: s.depsDepsService.GetApiDocsList,
+		GetSuccessList: s.depsDepsService.GetSuccessList,
 	}
 
 	apidoc, err := s.serviceInterface.GetSimpleAPIDocsList(ctx, &req, client)

--- a/codegen/tests/simple/serviceinterface.go
+++ b/codegen/tests/simple/serviceinterface.go
@@ -3,6 +3,7 @@ package simple
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/anz-bank/sysl-go/codegen/tests/deps"
@@ -60,6 +61,7 @@ type GetRawIntListClient struct {
 // GetSimpleAPIDocsList Client
 type GetSimpleAPIDocsListClient struct {
 	GetApiDocsList func(ctx context.Context, req *deps.GetApiDocsListRequest) (*deps.ApiDoc, error)
+	GetSuccessList func(ctx context.Context, req *deps.GetSuccessListRequest) (*http.Header, error)
 }
 
 // GetStuffList Client

--- a/codegen/transforms/svc_interface.sysl
+++ b/codegen/transforms/svc_interface.sysl
@@ -93,7 +93,10 @@ CodeGenTransform:
         let tn = ep.value.ret where (.key != "error" && .value != "ok" && .value != "error") -> <sequence of string>(t:
           out = makeType(t.value, package).out
         )
-        TypeName = Join(tn flatten(.out) | ["error"], ", ")
+        let ok = ep.value.ret where (.value == "ok") -> <sequence of string>(t:
+          out = "*http.Header"
+        )
+        TypeName = Join(tn flatten(.out) | ok flatten(.out) | ["error"], ", ")
       )
     )
 
@@ -224,7 +227,7 @@ CodeGenTransform:
         )
         let config = "github.com/anz-bank/sysl-go/config"
         let databaseImport = "database/sql"
-        let initWithoutDB = [config, "context", "time"]
+        let initWithoutDB = [config, "context", "time", "net/http"]
         let initWithDB = initWithoutDB | [databaseImport]
 
         let spec = if IsDataBaseApp(app).out then initWithDB else initWithoutDB | clientImports flatten(.out) -> <sequence of ImportSpec> (importPath:


### PR DESCRIPTION
Allows downstream to handle return <: ok.

1. Fixes the svc_interface transform.

Closes #104 