### PR TITLE
include endpoint params in method name #110

### DIFF
--- a/codegen/testdata/simple/simple.sysl
+++ b/codegen/testdata/simple/simple.sysl
@@ -19,9 +19,13 @@ Simple "Simple Server" [package="simple"]:
         GET:
             return ok <: str
 
-    /raw/{id<:string}/states:
+    /raw/{id<:string}/states [~vars_in_url_name]:
         GET:
-            return ok <: str    
+            return ok <: str
+
+    /raw/{id<:string}/states2:
+        GET:
+            return ok <: str     
 
     /raw-int:
         GET:

--- a/codegen/testdata/simple/simple.sysl
+++ b/codegen/testdata/simple/simple.sysl
@@ -23,7 +23,7 @@ Simple "Simple Server" [package="simple"]:
         GET:
             return ok <: str
 
-    /raw/{id<:string}/states2:
+    /raw/{id<:int64}/states2:
         GET:
             return ok <: str     
 

--- a/codegen/testdata/simple/simple.sysl
+++ b/codegen/testdata/simple/simple.sysl
@@ -15,6 +15,14 @@ Simple "Simple Server" [package="simple"]:
         GET:
             return ok <: str
 
+    /raw/states:
+        GET:
+            return ok <: str
+
+    /raw/{id<:string}/states:
+        GET:
+            return ok <: str    
+
     /raw-int:
         GET:
             return ok <: integer

--- a/codegen/tests/cards/grpc_interface.go
+++ b/codegen/tests/cards/grpc_interface.go
@@ -3,6 +3,7 @@ package cards
 
 import (
 	"context"
+	"time"
 
 	pb "github.com/anz-bank/sysl-go/codegen/tests/cardspb"
 )
@@ -14,4 +15,9 @@ type GetCardsClient struct {
 // GrpcServiceInterface for Cards
 type GrpcServiceInterface struct {
 	GetCards func(ctx context.Context, req *pb.GetCardsRequest, client GetCardsClient) (*pb.GetCardsResponse, error)
+}
+
+// DownstreamConfig for Cards
+type DownstreamConfig struct {
+	ContextTimeout time.Duration `yaml:"contextTimeout"`
 }

--- a/codegen/tests/deps/requestrouter.go
+++ b/codegen/tests/deps/requestrouter.go
@@ -41,6 +41,7 @@ func (s *ServiceRouter) WireRoutes(ctx context.Context, r chi.Router) {
 	r.Route(core.SelectBasePath(s.basePathFromSpec, s.gc.BasePath()), func(r chi.Router) {
 		s.gc.AddMiddleware(ctx, r)
 		r.Get("/api-docs", s.svcHandler.GetApiDocsListHandler)
+		r.Get("/success", s.svcHandler.GetSuccessListHandler)
 	})
 }
 

--- a/codegen/tests/deps/service.go
+++ b/codegen/tests/deps/service.go
@@ -71,21 +71,14 @@ func (s *Client) GetApiDocsList(ctx context.Context, req *GetApiDocsListRequest)
 // GetSuccessList ...
 func (s *Client) GetSuccessList(ctx context.Context, req *GetSuccessListRequest) (*http.Header, error) {
 	required := []string{}
-	var errorResponse Status
-
 	u, err := url.Parse(fmt.Sprintf("%s/success", s.url))
 	if err != nil {
 		return nil, common.CreateError(ctx, common.InternalError, "failed to parse url", err)
 	}
 
-	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, nil, &errorResponse)
+	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, nil, nil)
 	if err != nil {
-		response, ok := err.(*restlib.HTTPResult)
-		if !ok {
-			return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Deps <- GET "+u.String(), err)
-		}
-
-		return nil, common.CreateDownstreamError(ctx, common.DownstreamResponseError, response.HTTPResponse, response.Body, &errorResponse)
+		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Deps <- GET "+u.String(), err)
 	}
 
 	if result.HTTPResponse.StatusCode == http.StatusUnauthorized {

--- a/codegen/tests/simple/requestrouter.go
+++ b/codegen/tests/simple/requestrouter.go
@@ -49,6 +49,8 @@ func (s *ServiceRouter) WireRoutes(ctx context.Context, r chi.Router) {
 		r.Get("/oops", s.svcHandler.GetOopsListHandler)
 		r.Get("/raw", s.svcHandler.GetRawListHandler)
 		r.Get("/raw-int", s.svcHandler.GetRawIntListHandler)
+		r.Get("/raw/states", s.svcHandler.GetRawStatesListHandler)
+		r.Get("/raw/{id}/states", s.svcHandler.GetRawIdStatesListHandler)
 		r.Get("/simple-api-docs", s.svcHandler.GetSimpleAPIDocsListHandler)
 		r.Get("/stuff", s.svcHandler.GetStuffListHandler)
 		r.Post("/stuff", s.svcHandler.PostStuffHandler)

--- a/codegen/tests/simple/requestrouter.go
+++ b/codegen/tests/simple/requestrouter.go
@@ -51,6 +51,7 @@ func (s *ServiceRouter) WireRoutes(ctx context.Context, r chi.Router) {
 		r.Get("/raw-int", s.svcHandler.GetRawIntListHandler)
 		r.Get("/raw/states", s.svcHandler.GetRawStatesListHandler)
 		r.Get("/raw/{id}/states", s.svcHandler.GetRawIdStatesListHandler)
+		r.Get("/raw/{id}/states2", s.svcHandler.GetRawStates2ListHandler)
 		r.Get("/simple-api-docs", s.svcHandler.GetSimpleAPIDocsListHandler)
 		r.Get("/stuff", s.svcHandler.GetStuffListHandler)
 		r.Post("/stuff", s.svcHandler.PostStuffHandler)

--- a/codegen/tests/simple/service.go
+++ b/codegen/tests/simple/service.go
@@ -24,6 +24,8 @@ type Service interface {
 	GetOopsList(ctx context.Context, req *GetOopsListRequest) (*Response, error)
 	GetRawList(ctx context.Context, req *GetRawListRequest) (*Str, error)
 	GetRawIntList(ctx context.Context, req *GetRawIntListRequest) (*Integer, error)
+	GetRawStatesList(ctx context.Context, req *GetRawStatesListRequest) (*Str, error)
+	GetRawIdStatesList(ctx context.Context, req *GetRawIdStatesListRequest) (*Str, error)
 	GetSimpleAPIDocsList(ctx context.Context, req *GetSimpleAPIDocsListRequest) (*deps.ApiDoc, error)
 	GetStuffList(ctx context.Context, req *GetStuffListRequest) (*Stuff, error)
 	PostStuff(ctx context.Context, req *PostStuffRequest) (*Str, error)
@@ -294,6 +296,70 @@ func (s *Client) GetRawIntList(ctx context.Context, req *GetRawIntListRequest) (
 		}
 
 		return OkIntegerResponse, nil
+	}
+
+	return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, nil)
+}
+
+// GetRawStatesList ...
+func (s *Client) GetRawStatesList(ctx context.Context, req *GetRawStatesListRequest) (*Str, error) {
+	required := []string{}
+	var okResponse Str
+
+	u, err := url.Parse(fmt.Sprintf("%s/raw/states", s.url))
+	if err != nil {
+		return nil, common.CreateError(ctx, common.InternalError, "failed to parse url", err)
+	}
+
+	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	if err != nil {
+		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
+	}
+
+	if result.HTTPResponse.StatusCode == http.StatusUnauthorized {
+		return nil, common.CreateDownstreamError(ctx, common.DownstreamUnauthorizedError, result.HTTPResponse, result.Body, nil)
+	}
+
+	OkStrResponse, ok := result.Response.(*Str)
+	if ok {
+		valErr := validator.Validate(OkStrResponse)
+		if valErr != nil {
+			return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, valErr)
+		}
+
+		return OkStrResponse, nil
+	}
+
+	return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, nil)
+}
+
+// GetRawIdStatesList ...
+func (s *Client) GetRawIdStatesList(ctx context.Context, req *GetRawIdStatesListRequest) (*Str, error) {
+	required := []string{}
+	var okResponse Str
+
+	u, err := url.Parse(fmt.Sprintf("%s/raw/%v/states", s.url, req.ID))
+	if err != nil {
+		return nil, common.CreateError(ctx, common.InternalError, "failed to parse url", err)
+	}
+
+	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	if err != nil {
+		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
+	}
+
+	if result.HTTPResponse.StatusCode == http.StatusUnauthorized {
+		return nil, common.CreateDownstreamError(ctx, common.DownstreamUnauthorizedError, result.HTTPResponse, result.Body, nil)
+	}
+
+	OkStrResponse, ok := result.Response.(*Str)
+	if ok {
+		valErr := validator.Validate(OkStrResponse)
+		if valErr != nil {
+			return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, valErr)
+		}
+
+		return OkStrResponse, nil
 	}
 
 	return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, nil)

--- a/codegen/tests/simple/servicehandler.go
+++ b/codegen/tests/simple/servicehandler.go
@@ -31,6 +31,8 @@ type Handler interface {
 	GetOopsListHandler(w http.ResponseWriter, r *http.Request)
 	GetRawListHandler(w http.ResponseWriter, r *http.Request)
 	GetRawIntListHandler(w http.ResponseWriter, r *http.Request)
+	GetRawStatesListHandler(w http.ResponseWriter, r *http.Request)
+	GetRawIdStatesListHandler(w http.ResponseWriter, r *http.Request)
 	GetSimpleAPIDocsListHandler(w http.ResponseWriter, r *http.Request)
 	GetStuffListHandler(w http.ResponseWriter, r *http.Request)
 	PostStuffHandler(w http.ResponseWriter, r *http.Request)
@@ -338,6 +340,71 @@ func (s *ServiceHandler) GetRawIntListHandler(w http.ResponseWriter, r *http.Req
 	headermap, httpstatus := common.RespHeaderAndStatusFromContext(ctx)
 	restlib.SetHeaders(w, headermap)
 	restlib.SendHTTPResponse(w, httpstatus, integer)
+}
+
+// GetRawStatesListHandler ...
+func (s *ServiceHandler) GetRawStatesListHandler(w http.ResponseWriter, r *http.Request) {
+	if s.serviceInterface.GetRawStatesList == nil {
+		common.HandleError(r.Context(), w, common.InternalError, "not implemented", nil, s.genCallback.MapError)
+		return
+	}
+
+	ctx := common.RequestHeaderToContext(r.Context(), r.Header)
+	ctx = common.RespHeaderAndStatusToContext(ctx, make(http.Header), http.StatusOK)
+	var req GetRawStatesListRequest
+
+	ctx, cancel := s.genCallback.DownstreamTimeoutContext(ctx)
+	defer cancel()
+	valErr := validator.Validate(&req)
+	if valErr != nil {
+		common.HandleError(ctx, w, common.BadRequestError, "Invalid request", valErr, s.genCallback.MapError)
+		return
+	}
+
+	client := GetRawStatesListClient{}
+
+	str, err := s.serviceInterface.GetRawStatesList(ctx, &req, client)
+	if err != nil {
+		common.HandleError(ctx, w, common.DownstreamUnexpectedResponseError, "Downstream failure", err, s.genCallback.MapError)
+		return
+	}
+
+	headermap, httpstatus := common.RespHeaderAndStatusFromContext(ctx)
+	restlib.SetHeaders(w, headermap)
+	restlib.SendHTTPResponse(w, httpstatus, str)
+}
+
+// GetRawIdStatesListHandler ...
+func (s *ServiceHandler) GetRawIdStatesListHandler(w http.ResponseWriter, r *http.Request) {
+	if s.serviceInterface.GetRawIdStatesList == nil {
+		common.HandleError(r.Context(), w, common.InternalError, "not implemented", nil, s.genCallback.MapError)
+		return
+	}
+
+	ctx := common.RequestHeaderToContext(r.Context(), r.Header)
+	ctx = common.RespHeaderAndStatusToContext(ctx, make(http.Header), http.StatusOK)
+	var req GetRawIdStatesListRequest
+
+	req.ID = restlib.GetURLParam(r, "id")
+	ctx, cancel := s.genCallback.DownstreamTimeoutContext(ctx)
+	defer cancel()
+	valErr := validator.Validate(&req)
+	if valErr != nil {
+		common.HandleError(ctx, w, common.BadRequestError, "Invalid request", valErr, s.genCallback.MapError)
+		return
+	}
+
+	client := GetRawIdStatesListClient{}
+
+	str, err := s.serviceInterface.GetRawIdStatesList(ctx, &req, client)
+	if err != nil {
+		common.HandleError(ctx, w, common.DownstreamUnexpectedResponseError, "Downstream failure", err, s.genCallback.MapError)
+		return
+	}
+
+	headermap, httpstatus := common.RespHeaderAndStatusFromContext(ctx)
+	restlib.SetHeaders(w, headermap)
+	restlib.SendHTTPResponse(w, httpstatus, str)
 }
 
 // GetSimpleAPIDocsListHandler ...

--- a/codegen/tests/simple/servicehandler.go
+++ b/codegen/tests/simple/servicehandler.go
@@ -419,7 +419,7 @@ func (s *ServiceHandler) GetRawStates2ListHandler(w http.ResponseWriter, r *http
 	ctx = common.RespHeaderAndStatusToContext(ctx, make(http.Header), http.StatusOK)
 	var req GetRawStates2ListRequest
 
-	req.ID = restlib.GetURLParam(r, "id")
+	req.ID = restlib.GetURLParamForInt(r, "id")
 	ctx, cancel := s.genCallback.DownstreamTimeoutContext(ctx)
 	defer cancel()
 	valErr := validator.Validate(&req)

--- a/codegen/tests/simple/servicehandler.go
+++ b/codegen/tests/simple/servicehandler.go
@@ -33,6 +33,7 @@ type Handler interface {
 	GetRawIntListHandler(w http.ResponseWriter, r *http.Request)
 	GetRawStatesListHandler(w http.ResponseWriter, r *http.Request)
 	GetRawIdStatesListHandler(w http.ResponseWriter, r *http.Request)
+	GetRawStates2ListHandler(w http.ResponseWriter, r *http.Request)
 	GetSimpleAPIDocsListHandler(w http.ResponseWriter, r *http.Request)
 	GetStuffListHandler(w http.ResponseWriter, r *http.Request)
 	PostStuffHandler(w http.ResponseWriter, r *http.Request)
@@ -397,6 +398,39 @@ func (s *ServiceHandler) GetRawIdStatesListHandler(w http.ResponseWriter, r *htt
 	client := GetRawIdStatesListClient{}
 
 	str, err := s.serviceInterface.GetRawIdStatesList(ctx, &req, client)
+	if err != nil {
+		common.HandleError(ctx, w, common.DownstreamUnexpectedResponseError, "Downstream failure", err, s.genCallback.MapError)
+		return
+	}
+
+	headermap, httpstatus := common.RespHeaderAndStatusFromContext(ctx)
+	restlib.SetHeaders(w, headermap)
+	restlib.SendHTTPResponse(w, httpstatus, str)
+}
+
+// GetRawStates2ListHandler ...
+func (s *ServiceHandler) GetRawStates2ListHandler(w http.ResponseWriter, r *http.Request) {
+	if s.serviceInterface.GetRawStates2List == nil {
+		common.HandleError(r.Context(), w, common.InternalError, "not implemented", nil, s.genCallback.MapError)
+		return
+	}
+
+	ctx := common.RequestHeaderToContext(r.Context(), r.Header)
+	ctx = common.RespHeaderAndStatusToContext(ctx, make(http.Header), http.StatusOK)
+	var req GetRawStates2ListRequest
+
+	req.ID = restlib.GetURLParam(r, "id")
+	ctx, cancel := s.genCallback.DownstreamTimeoutContext(ctx)
+	defer cancel()
+	valErr := validator.Validate(&req)
+	if valErr != nil {
+		common.HandleError(ctx, w, common.BadRequestError, "Invalid request", valErr, s.genCallback.MapError)
+		return
+	}
+
+	client := GetRawStates2ListClient{}
+
+	str, err := s.serviceInterface.GetRawStates2List(ctx, &req, client)
 	if err != nil {
 		common.HandleError(ctx, w, common.DownstreamUnexpectedResponseError, "Downstream failure", err, s.genCallback.MapError)
 		return

--- a/codegen/tests/simple/serviceinterface.go
+++ b/codegen/tests/simple/serviceinterface.go
@@ -66,6 +66,10 @@ type GetRawStatesListClient struct {
 type GetRawIdStatesListClient struct {
 }
 
+// GetRawStates2List Client
+type GetRawStates2ListClient struct {
+}
+
 // GetSimpleAPIDocsList Client
 type GetSimpleAPIDocsListClient struct {
 	GetApiDocsList func(ctx context.Context, req *deps.GetApiDocsListRequest) (*deps.ApiDoc, error)
@@ -93,6 +97,7 @@ type ServiceInterface struct {
 	GetRawIntList             func(ctx context.Context, req *GetRawIntListRequest, client GetRawIntListClient) (*Integer, error)
 	GetRawStatesList          func(ctx context.Context, req *GetRawStatesListRequest, client GetRawStatesListClient) (*Str, error)
 	GetRawIdStatesList        func(ctx context.Context, req *GetRawIdStatesListRequest, client GetRawIdStatesListClient) (*Str, error)
+	GetRawStates2List         func(ctx context.Context, req *GetRawStates2ListRequest, client GetRawStates2ListClient) (*Str, error)
 	GetSimpleAPIDocsList      func(ctx context.Context, req *GetSimpleAPIDocsListRequest, client GetSimpleAPIDocsListClient) (*deps.ApiDoc, error)
 	GetStuffList              func(ctx context.Context, req *GetStuffListRequest, client GetStuffListClient) (*Stuff, error)
 	PostStuff                 func(ctx context.Context, req *PostStuffRequest, client PostStuffClient) (*Str, error)

--- a/codegen/tests/simple/serviceinterface.go
+++ b/codegen/tests/simple/serviceinterface.go
@@ -58,6 +58,14 @@ type GetRawListClient struct {
 type GetRawIntListClient struct {
 }
 
+// GetRawStatesList Client
+type GetRawStatesListClient struct {
+}
+
+// GetRawIdStatesList Client
+type GetRawIdStatesListClient struct {
+}
+
 // GetSimpleAPIDocsList Client
 type GetSimpleAPIDocsListClient struct {
 	GetApiDocsList func(ctx context.Context, req *deps.GetApiDocsListRequest) (*deps.ApiDoc, error)
@@ -83,6 +91,8 @@ type ServiceInterface struct {
 	GetOopsList               func(ctx context.Context, req *GetOopsListRequest, client GetOopsListClient) (*Response, error)
 	GetRawList                func(ctx context.Context, req *GetRawListRequest, client GetRawListClient) (*Str, error)
 	GetRawIntList             func(ctx context.Context, req *GetRawIntListRequest, client GetRawIntListClient) (*Integer, error)
+	GetRawStatesList          func(ctx context.Context, req *GetRawStatesListRequest, client GetRawStatesListClient) (*Str, error)
+	GetRawIdStatesList        func(ctx context.Context, req *GetRawIdStatesListRequest, client GetRawIdStatesListClient) (*Str, error)
 	GetSimpleAPIDocsList      func(ctx context.Context, req *GetSimpleAPIDocsListRequest, client GetSimpleAPIDocsListClient) (*deps.ApiDoc, error)
 	GetStuffList              func(ctx context.Context, req *GetStuffListRequest, client GetStuffListClient) (*Stuff, error)
 	PostStuff                 func(ctx context.Context, req *PostStuffRequest, client PostStuffClient) (*Str, error)

--- a/codegen/tests/simple/simple.go
+++ b/codegen/tests/simple/simple.go
@@ -16,6 +16,12 @@ func GetRawIntList(ctx context.Context, req *GetRawIntListRequest, client GetRaw
 	return &s, nil
 }
 
+func GetRawIdStatesList(ctx context.Context, req *GetRawIdStatesListRequest, client GetRawIdStatesListClient) (*Str, error) {
+	var s Str = "raw"
+
+	return &s, nil
+}
+
 func GetStuffList(ctx context.Context, req *GetStuffListRequest, client GetStuffListClient) (*Stuff, error) {
 	s := Stuff{
 		InnerStuff: "response",

--- a/codegen/tests/simple/types.go
+++ b/codegen/tests/simple/types.go
@@ -85,6 +85,15 @@ type GetRawListRequest struct {
 type GetRawIntListRequest struct {
 }
 
+// GetRawStatesListRequest ...
+type GetRawStatesListRequest struct {
+}
+
+// GetRawIdStatesListRequest ...
+type GetRawIdStatesListRequest struct {
+	ID string
+}
+
 // GetSimpleAPIDocsListRequest ...
 type GetSimpleAPIDocsListRequest struct {
 }

--- a/codegen/tests/simple/types.go
+++ b/codegen/tests/simple/types.go
@@ -94,6 +94,11 @@ type GetRawIdStatesListRequest struct {
 	ID string
 }
 
+// GetRawStates2ListRequest ...
+type GetRawStates2ListRequest struct {
+	ID string
+}
+
 // GetSimpleAPIDocsListRequest ...
 type GetSimpleAPIDocsListRequest struct {
 }

--- a/codegen/tests/simple/types.go
+++ b/codegen/tests/simple/types.go
@@ -96,7 +96,7 @@ type GetRawIdStatesListRequest struct {
 
 // GetRawStates2ListRequest ...
 type GetRawStates2ListRequest struct {
-	ID string
+	ID int64
 }
 
 // GetSimpleAPIDocsListRequest ...

--- a/codegen/tests/wallet/grpc_interface.go
+++ b/codegen/tests/wallet/grpc_interface.go
@@ -3,6 +3,7 @@ package wallet
 
 import (
 	"context"
+	"time"
 
 	pb "github.com/anz-bank/sysl-go/codegen/tests/cardspb"
 )
@@ -14,4 +15,9 @@ type AppleClient struct {
 // GrpcServiceInterface for Wallet
 type GrpcServiceInterface struct {
 	Apple func(ctx context.Context, req *pb.AppleRequest, client AppleClient) (*pb.AppleResponse, error)
+}
+
+// DownstreamConfig for Wallet
+type DownstreamConfig struct {
+	ContextTimeout time.Duration `yaml:"contextTimeout"`
 }

--- a/codegen/transforms/svc_client.sysl
+++ b/codegen/transforms/svc_client.sysl
@@ -73,7 +73,7 @@ CodeGenTransform:
       let withArg = if MatchString("\\{\\p{L}+\\}$", urlPath) && Contains("POST", ToUpper(method)) then "WithArg" else ""
       let getList = if MatchString("[\\p{L}\\p{N}]$", urlPath) && Contains("GET", ToUpper(method)) then "List" else ""
 
-      let path = Split(Replace(Replace(urlPath, "{", "", -1),"{","",-1), "/")
+      let path = Split(urlPath, "/")
 
       let methodPostfix = path -> <sequence of string> (p:
         let postfix = if MatchString("^\\{", p) then "" else p
@@ -538,7 +538,9 @@ CodeGenTransform:
 
   !view ClientMethods(appName <: string, eps <: set of sysl.Endpoints, module <: sysl.Module) -> sequence of TopLevelDecl:
     eps -> (ep:
-      let funcName = methodName(ep.value.method, ep.value.path).out
+      let Patterns = if ep.attrs count > 0 && "patterns" in ep.attrs then ep.attrs.patterns else [""]
+      let urlPath = if "vars_in_url_name" in Patterns then Replace(Replace(ep.value.path, "{", "", -1),"{","",-1) else ep.value.path
+      let funcName = methodName(ep.value.method, urlPath).out
       Comment = '// ' + funcName + ' ...'
       MethodDecl = ep -> <MethodDecl>(:
         Receiver = ep -> <Receiver>(:
@@ -609,7 +611,9 @@ CodeGenTransform:
             Identifier = "ctx"
             TypeName = "context.Context"
           )
-          let requestParam = methodName(ep.value.method, ep.value.path).out -> <Param>(:
+          let Patterns = if ep.attrs count > 0 && "patterns" in ep.attrs then ep.attrs.patterns else [""]
+          let urlPath = if "vars_in_url_name" in Patterns then Replace(Replace(ep.value.path, "{", "", -1),"{","",-1) else ep.value.path
+          let requestParam = methodName(ep.value.method, urlPath).out -> <Param>(:
             ident = "req"
             typ = "*" + . + "Request"
           )
@@ -627,7 +631,9 @@ CodeGenTransform:
 
   !view GoMethods(eps <: set of sysl.Endpoints, module <: sysl.Module) -> sequence of MethodSpec:
     eps -> (ep:
-      MethodName = methodName(ep.value.method, ep.value.path).out
+      let Patterns = if ep.attrs count > 0 && "patterns" in ep.attrs then ep.attrs.patterns else [""]
+      let urlPath = if "vars_in_url_name" in Patterns then Replace(Replace(ep.value.path, "{", "", -1),"{","",-1) else ep.value.path
+      MethodName = methodName(ep.value.method, urlPath).out
       Signature = methodSignature(ep, module)
     )
 

--- a/codegen/transforms/svc_client.sysl
+++ b/codegen/transforms/svc_client.sysl
@@ -73,7 +73,7 @@ CodeGenTransform:
       let withArg = if MatchString("\\{\\p{L}+\\}$", urlPath) && Contains("POST", ToUpper(method)) then "WithArg" else ""
       let getList = if MatchString("[\\p{L}\\p{N}]$", urlPath) && Contains("GET", ToUpper(method)) then "List" else ""
 
-      let path = Split(urlPath, "/")
+      let path = Split(Replace(Replace(urlPath, "{", "", -1),"{","",-1), "/")
 
       let methodPostfix = path -> <sequence of string> (p:
         let postfix = if MatchString("^\\{", p) then "" else p

--- a/codegen/transforms/svc_handler.sysl
+++ b/codegen/transforms/svc_handler.sysl
@@ -357,7 +357,9 @@ CodeGenTransform:
         out = "{" + .name + "}"
       )
       let pathVars = terms flatten(.out)
-      let path = Split(Replace(Replace(ep.value.path, "{", "", -1),"{","",-1), "/")
+      
+      let Patterns = if ep.attrs count > 0 && "patterns" in ep.attrs then ep.attrs.patterns else [""]
+      let path = if "vars_in_url_name" in Patterns then Split(Replace(Replace(ep.value.path, "{", "", -1),"{","",-1), "/") else Split(ep.value.path, "/")
       let method = Title(ToLower(ep.value.method))
 
       let methodPostfix = path -> <sequence of string> (p:

--- a/codegen/transforms/svc_handler.sysl
+++ b/codegen/transforms/svc_handler.sysl
@@ -357,7 +357,7 @@ CodeGenTransform:
         out = "{" + .name + "}"
       )
       let pathVars = terms flatten(.out)
-      let path = Split(ep.value.path, "/")
+      let path = Split(Replace(Replace(ep.value.path, "{", "", -1),"{","",-1), "/")
       let method = Title(ToLower(ep.value.method))
 
       let methodPostfix = path -> <sequence of string> (p:

--- a/codegen/transforms/svc_handler.sysl
+++ b/codegen/transforms/svc_handler.sysl
@@ -514,11 +514,12 @@ CodeGenTransform:
 
   !view getReqVars(allParams <: AllParams) -> Block:
     allParams -> (:
-      let pps = getParamStatements(allParams.PathParams, "restlib.GetURLParam")
+      let intpps = getParamStatements(allParams.PathParams where(.paramType == "int64"), "restlib.GetURLParamForInt")
+      let pps = getParamStatements(allParams.PathParams  where(.paramType != "int64"), "restlib.GetURLParam")
       let reqQps = getParamStatements(allParams.ReqQueryParams, "restlib.GetQueryParam")
       let optQps = getOptParamStatements(allParams.OptQueryParams, "restlib.GetQueryParam").StatementList
       let reqHs = getParamStatementsDecl(allParams.ReqHeaderParams, "restlib.GetHeaderParam")
-      StatementList = pps | reqQps | optQps | reqHs
+      StatementList = intpps | pps | reqQps | optQps | reqHs
     )
 
   !view getBodyParams(bodyParams <: BodyParams, packageName <: string) -> Block:

--- a/codegen/transforms/svc_interface.sysl
+++ b/codegen/transforms/svc_interface.sysl
@@ -51,7 +51,7 @@ CodeGenTransform:
         out = "{" + .name + "}"
       )
       let pathVars = terms flatten(.out)
-      let path = Split(ep.value.path, "/")
+      let path = Split(Replace(Replace(ep.value.path, "{", "", -1),"{","",-1), "/")
       let method = Title(ToLower(ep.value.method))
 
       let methodPostfix = path -> <string> (:

--- a/codegen/transforms/svc_interface.sysl
+++ b/codegen/transforms/svc_interface.sysl
@@ -51,7 +51,9 @@ CodeGenTransform:
         out = "{" + .name + "}"
       )
       let pathVars = terms flatten(.out)
-      let path = Split(Replace(Replace(ep.value.path, "{", "", -1),"{","",-1), "/")
+      
+      let Patterns = if ep.attrs count > 0 && "patterns" in ep.attrs then ep.attrs.patterns else [""]
+      let path = if "vars_in_url_name" in Patterns then Split(Replace(Replace(ep.value.path, "{", "", -1),"{","",-1), "/") else Split(ep.value.path, "/")
       let method = Title(ToLower(ep.value.method))
 
       let methodPostfix = path -> <string> (:

--- a/codegen/transforms/svc_router.sysl
+++ b/codegen/transforms/svc_router.sysl
@@ -54,9 +54,9 @@ CodeGenTransform:
         out = "{" + .name + "}"
       )
       let pathVars = terms flatten(.out)
-      let path = Split(ep.value.path, "/")
+      let path = Split(Replace(Replace(ep.value.path, "{", "", -1),"{","",-1), "/")
       let method = Title(ToLower(ep.value.method))
-
+      let rawpath = Split(ep.value.path, "/")
       let methodPostfix = path -> <sequence of string> (p:
         let postfix  = if p in pathVars then "" else p
         out = Title(ToLower(postfix))
@@ -65,7 +65,7 @@ CodeGenTransform:
       let getList = if MatchString("[\\p{L}\\p{N}]$", ep.value.path) && Contains("GET", ToUpper(method)) then "List" else ""
 
       let handlerCall = "s." + "svcHandler" + "." + GoName(method + Join(methodPostfix flatten(.out), "") + withArg + getList).out + "Handler"
-      let epPath =  '"' + Join(path, "/") + '"'
+      let epPath =  '"' + Join(rawpath, "/") + '"'
       let funcName = "r." + method
 
       let nilCheck = handlerCall -> <Statement>(:

--- a/codegen/transforms/svc_router.sysl
+++ b/codegen/transforms/svc_router.sysl
@@ -53,8 +53,9 @@ CodeGenTransform:
       let terms = ep.value.pathvars -> <out> (:
         out = "{" + .name + "}"
       )
-      let pathVars = terms flatten(.out)
-      let path = Split(Replace(Replace(ep.value.path, "{", "", -1),"{","",-1), "/")
+      let pathVars = terms flatten(.out)    
+      let Patterns = if ep.attrs count > 0 && "patterns" in ep.attrs then ep.attrs.patterns else [""]
+      let path = if "vars_in_url_name" in Patterns then Split(Replace(Replace(ep.value.path, "{", "", -1),"{","",-1), "/") else Split(ep.value.path, "/")
       let method = Title(ToLower(ep.value.method))
       let rawpath = Split(ep.value.path, "/")
       let methodPostfix = path -> <sequence of string> (p:

--- a/codegen/transforms/svc_types.sysl
+++ b/codegen/transforms/svc_types.sysl
@@ -237,7 +237,7 @@ CodeGenTransform:
       let withArg = if MatchString("\\{\\p{L}+\\}$", urlPath) && Contains("POST", ToUpper(method)) then "WithArg" else ""
       let getList = if MatchString("[\\p{L}\\p{N}]$", urlPath) && Contains("GET", ToUpper(method)) then "List" else ""
 
-      let path = Split(Replace(Replace(urlPath, "{", "", -1),"{","",-1), "/")
+      let path = Split(urlPath, "/")
 
       let methodPostfix = path -> <sequence of string> (p:
         let postfix = if MatchString("^\\{", p) then "" else p
@@ -268,7 +268,9 @@ CodeGenTransform:
 
   !view RequestTypes(eps <: sequence of sysl.Endpoint, module <: sysl.Module) -> sequence of TopLevelDecl:
     eps -> (ep:
-      let typeName = methodName(ep.value.method, ep.value.path).out + "Request"
+      let Patterns = if ep.attrs count > 0 && "patterns" in ep.attrs then ep.attrs.patterns else [""]
+      let urlPath = if "vars_in_url_name" in Patterns then Replace(Replace(ep.value.path, "{", "", -1),"{","",-1) else ep.value.path
+      let typeName = methodName(ep.value.method, urlPath).out + "Request"
       Comment = '// ' + typeName + ' ...'
       Declaration = ep -> <Declaration>(:
         StructType = ep -> <StructType>(:

--- a/codegen/transforms/svc_types.sysl
+++ b/codegen/transforms/svc_types.sysl
@@ -237,7 +237,7 @@ CodeGenTransform:
       let withArg = if MatchString("\\{\\p{L}+\\}$", urlPath) && Contains("POST", ToUpper(method)) then "WithArg" else ""
       let getList = if MatchString("[\\p{L}\\p{N}]$", urlPath) && Contains("GET", ToUpper(method)) then "List" else ""
 
-      let path = Split(urlPath, "/")
+      let path = Split(Replace(Replace(urlPath, "{", "", -1),"{","",-1), "/")
 
       let methodPostfix = path -> <sequence of string> (p:
         let postfix = if MatchString("^\\{", p) then "" else p

--- a/restlib/common.go
+++ b/restlib/common.go
@@ -2,6 +2,7 @@ package restlib
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/go-chi/chi"
 )
@@ -9,6 +10,12 @@ import (
 func GetURLParam(r *http.Request, key string) string {
 	return chi.URLParam(r, key)
 }
+
+func GetURLParamForInt(r *http.Request, key string) int64 {
+	result, _ := strconv.ParseInt(chi.URLParam(r, key), 10, 64)
+	return result
+}
+
 func GetQueryParam(r *http.Request, key string) string {
 	return r.URL.Query().Get(key)
 }


### PR DESCRIPTION
Generate method name to include route params

Add an example in simple.sysl
Fixes the svc_handler transform.
Fixes the svc_interface transform.
Fixes the svc_client transform.
Fixes the svc_type transform.
Fixes the svc_router transform.

Closes #110 