### PR TITLE
insert logger to ctx in middleware #125

### DIFF
--- a/common/corerequestcontext_test.go
+++ b/common/corerequestcontext_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestCoreRequestContextMiddleware(t *testing.T) {
-	_, _, ctx := NewTestCoreRequestContext()
-	mware := CoreRequestContextMiddleware()
+	logger, _, ctx := NewTestCoreRequestContext()
+	mware := CoreRequestContextMiddleware(logger)
 	body := bytes.NewBufferString("test")
 	req, err := http.NewRequest("GET", "localhost/", body)
 	require.Nil(t, err)
@@ -20,6 +20,7 @@ func TestCoreRequestContextMiddleware(t *testing.T) {
 	fn := mware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		coreCtx := getCoreContext(r.Context())
 		require.NotNil(t, coreCtx)
+		require.Equal(t, logger, coreCtx.logger)
 	}))
 
 	fn.ServeHTTP(nil, req)


### PR DESCRIPTION
insert logger to ctx in corecontextmiddleware #125
- update corecontextmiddleware to take in the *logrus logger params, insert into context if there is no logger in the context.