### PR TITLE
refactor corerequestcontext to pass logger #129

### DIFF
--- a/core/http.go
+++ b/core/http.go
@@ -138,7 +138,7 @@ func prepareMiddleware(ctx context.Context, name string, promRegistry *prometheu
 	result.addToBoth(Recoverer(ctx))
 
 	result.public = append(result.public, common.TraceabilityMiddleware(ctx))
-	result.addToBoth(common.CoreRequestContextMiddleware())
+	result.addToBoth(common.CoreRequestContextMiddlewareWithContext(ctx))
 
 	if promRegistry != nil {
 		metricsMiddleware := metrics.NewHTTPServerMetricsMiddleware(promRegistry, name, metrics.GetChiPathPattern)

--- a/core/http_test.go
+++ b/core/http_test.go
@@ -46,7 +46,7 @@ func Test_prepareMiddleware(t *testing.T) {
 			want: []func(http.Handler) http.Handler{
 				Recoverer(ctx),
 				common.TraceabilityMiddleware(ctx),
-				common.CoreRequestContextMiddleware(),
+				common.CoreRequestContextMiddlewareWithContext(ctx),
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
- Update `CoreRequestContextMiddleware` in `corerequestcontext.go` to pass in the logger directly or from context.
- Update related tests 