### PR TITLE
Change str.split to seq.split

### DIFF
--- a/codegen/arrai/grpc_client.arrai
+++ b/codegen/arrai/grpc_client.arrai
@@ -43,7 +43,7 @@
         let param_name = \p p("type")("typeRef")("ref")("appname")("part").a >> .s;
 
         # kind of hardcoded binding assuming the return statment is in the format "ok <: (result)"
-        let ret_param = \statements statements >> //str.split(.("ret")("payload").s, " ")(2);
+        let ret_param = \statements statements >> //seq.split(.("ret")("payload").s, " ")(2);
 
         $`
             // Package ${jsontool.attr("go_package", app)} ...


### PR DESCRIPTION
`//str.split` was replaced by `//seq.split` in https://github.com/arr-ai/arrai/pull/240.