### PR TITLE
Attach verbose logging level to request context

### DIFF
--- a/common/corerequestcontext.go
+++ b/common/corerequestcontext.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/anz-bank/sysl-go/logconfig"
+
 	"github.com/anz-bank/sysl-go/common/internal"
 
 	"github.com/anz-bank/pkg/log"
@@ -104,12 +106,14 @@ func CoreRequestContextMiddleware(logger *logrus.Logger) func(next http.Handler)
 func CoreRequestContextMiddlewareWithContext(ctx context.Context) func(next http.Handler) http.Handler {
 	ctxlogger := GetLoggerFromContext(ctx)
 	pkgLogger := log.From(ctx)
+	verboseLogging := logconfig.IsVerboseLogging(ctx)
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 			ctx = LoggerToContext(ctx, ctxlogger, nil)
 			ctx = log.WithLogger(pkgLogger).Onto(ctx)
 			ctx = log.With(traceIDLogField, GetTraceIDFromContext(ctx)).Onto(ctx)
+			ctx = logconfig.SetVerboseLogging(ctx, verboseLogging)
 
 			ctx = internal.AddResponseBodyMonitorToContext(ctx)
 			defer internal.CheckForUnclosedResponses(ctx)

--- a/common/internal/requestlogger.go
+++ b/common/internal/requestlogger.go
@@ -79,7 +79,7 @@ func (r *nopLogger) ResponseWriter(base http.ResponseWriter) http.ResponseWriter
 func (r *nopLogger) FlushLog()                                                   {}
 
 func NewRequestLogger(ctx context.Context, req *http.Request) (RequestLogger, context.Context) {
-	if isVerboseLogging(ctx) {
+	if logconfig.IsVerboseLogging(ctx) {
 		l := &requestLogger{
 			ctx:        InitFieldsFromRequest(req).Onto(ctx),
 			protoMajor: req.ProtoMajor,
@@ -94,12 +94,4 @@ func NewRequestLogger(ctx context.Context, req *http.Request) (RequestLogger, co
 		return l, l.ctx
 	}
 	return &nopLogger{}, ctx
-}
-
-func isVerboseLogging(ctx context.Context) bool {
-	v, ok := ctx.Value(logconfig.IsVerboseLoggingKey{}).(*logconfig.IsVerboseLogging)
-	if ok {
-		return v.Flag
-	}
-	return false
 }

--- a/common/internal/requestlogger_test.go
+++ b/common/internal/requestlogger_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/anz-bank/sysl-go/logconfig"
 	"github.com/anz-bank/sysl-go/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -37,10 +38,11 @@ func TestLogger_FlushLog(t *testing.T) {
 	}
 	l.LogResponse(&resp)
 
-	require.Empty(t, hook.Entries)
+	require.Equal(t, 2, len(hook.Entries))
 
 	l.FlushLog()
-	require.NotEmpty(t, hook.Entries)
+	require.Equal(t, 3, len(hook.Entries))
+	require.Equal(t, "Already flushed the request", hook.LastEntry().Message)
 }
 
 func TestRequestLogger_NilBody(t *testing.T) {
@@ -57,6 +59,7 @@ func TestRequestLogger_NilBody(t *testing.T) {
 func TestRequestLogger_ResponseWriter(t *testing.T) {
 	ctx, hook := testutil.NewTestContextWithLoggerHook()
 
+	ctx = logconfig.SetVerboseLogging(ctx, false)
 	req, err := http.NewRequest("GET", "http://example.com/foo", nil)
 	require.NoError(t, err)
 

--- a/core/server.go
+++ b/core/server.go
@@ -6,9 +6,10 @@ import (
 	"context"
 	"errors"
 
+	"github.com/anz-bank/sysl-go/logconfig"
+
 	"github.com/anz-bank/pkg/log"
 	"github.com/anz-bank/sysl-go/common"
-	"github.com/anz-bank/sysl-go/logconfig"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
@@ -69,11 +70,8 @@ func (params *ServerParams) Start() error {
 		}
 	}
 
-	ctx = context.WithValue(ctx, logconfig.IsVerboseLoggingKey{},
-		&logconfig.IsVerboseLogging{
-			Flag: verboseLogging,
-		})
 	// prepare the middleware
+	ctx = logconfig.SetVerboseLogging(ctx, verboseLogging)
 	mWare := prepareMiddleware(ctx, params.Name, params.prometheusRegistry)
 
 	var restIsRunning, grpcIsRunning bool

--- a/logconfig/logLevel.go
+++ b/logconfig/logLevel.go
@@ -1,6 +1,0 @@
-package logconfig
-
-type IsVerboseLoggingKey struct{}
-type IsVerboseLogging struct {
-	Flag bool
-}

--- a/logconfig/logconfig.go
+++ b/logconfig/logconfig.go
@@ -1,0 +1,27 @@
+package logconfig
+
+import (
+	"context"
+)
+
+type isVerboseLoggingKey struct{}
+type isVerboseLogging struct {
+	Flag bool
+}
+
+// Get whether or not sysl-go internals log additional debug/verbose level information.
+func IsVerboseLogging(ctx context.Context) bool {
+	v, ok := ctx.Value(isVerboseLoggingKey{}).(*isVerboseLogging)
+	if ok {
+		return v.Flag
+	}
+	return false
+}
+
+// Set against the context whether or not sysl-go internals log additional debug/verbose level information.
+func SetVerboseLogging(ctx context.Context, verbose bool) context.Context {
+	return context.WithValue(ctx, isVerboseLoggingKey{},
+		&isVerboseLogging{
+			Flag: verbose,
+		})
+}

--- a/testutil/test_util.go
+++ b/testutil/test_util.go
@@ -26,10 +26,8 @@ func (t *TestHook) LastEntry() *log.LogEntry {
 
 func NewTestContextWithLoggerHook() (context.Context, *TestHook) {
 	loghook := TestHook{}
-	ctxWithValue := context.WithValue(context.Background(), logconfig.IsVerboseLoggingKey{},
-		&logconfig.IsVerboseLogging{
-			Flag: true,
-		})
-	ctx := log.WithConfigs(log.AddHooks(&loghook)).Onto(ctxWithValue)
+	ctx := logconfig.SetVerboseLogging(context.Background(), true)
+	ctx = log.WithConfigs(log.SetVerboseMode(true)).Onto(ctx)
+	ctx = log.WithConfigs(log.AddHooks(&loghook)).Onto(ctx)
 	return ctx, &loghook
 }


### PR DESCRIPTION
Internally, sysl-go uses a value attached to the context to
track whether or not additional debug/verbose-level information is
attached to its logs. In order for this value to persist within a
request, it must also be attached to the request context.

Closes #150