### PR TITLE
Temporarily remove json type generation

### DIFF
--- a/codegen/arrai/service.arrai
+++ b/codegen/arrai/service.arrai
@@ -5,8 +5,8 @@ let sysl = //{./sysl};
 
 # codegen groups
 
-let restClient = {"error_types", "service", "types", "types_extn"};
-let restService = restClient | {"requestrouter", "servicehandler", "serviceinterface", "types_extn"};
+let restClient = {"error_types", "service", "types"};
+let restService = restClient | {"requestrouter", "servicehandler", "serviceinterface"};
 
 let grpcClient = {"grpc_client"};
 let grpcService = grpcClient | {"grpc_handler", "grpc_interface"};


### PR DESCRIPTION
To remove an issue that would result in an infinite loop during
execution, temporarily remove the types_extn file from the set of
files generated in service.arrai