### PR TITLE
Include RestRequestOption interface and OnResult implementation

### DIFF
--- a/restlib/restlib.go
+++ b/restlib/restlib.go
@@ -188,3 +188,29 @@ func SetHeaders(w http.ResponseWriter, headerMap http.Header) {
 		}
 	}
 }
+
+// RestRequestOption is an interface that marks options that can be passed to downstream REST requests.
+type RestRequestOption interface {
+	restRequestOption()
+}
+
+// RestRequestOnResult returns a RestRequestOption that can be passed to a downstream REST request.
+// The function passed in will be called immediately after a downstream response is retrieved.
+func RestRequestOnResult(f func(result *HTTPResult, err error)) RestRequestOption {
+	return onResultRestRequestOption{f}
+}
+
+type onResultRestRequestOption struct {
+	onResult func(result *HTTPResult, err error)
+}
+
+func (o onResultRestRequestOption) restRequestOption() {}
+
+// OnRestRequestResult is called from generated code when an HTTP result is retrieved.
+func OnRestRequestResult(result *HTTPResult, err error, opts []RestRequestOption) {
+	for _, opt := range opts {
+		if onResult, ok := opt.(*onResultRestRequestOption); ok {
+			onResult.onResult(result, err)
+		}
+	}
+}


### PR DESCRIPTION
Custom handler implementations in some instances require access to
more information than downstream service calls currently permit. This
can include the status code, headers or body in the instance that a
non-successful response was returned.

RestRequestOption instances can be passed into downstream REST
requests to perform custom actions:

```go
response, err := client.GetRestFooBar(ctx, &request,
    restlib.RestRequestOnResult(func(result *restlib.HTTPResult, err error) {
        // access to raw http result and error
    }))
```

Closes #105 #159