### PR TITLE
Include RestRequestOption interface and OnResult implementation

### DIFF
--- a/restlib/restlib.go
+++ b/restlib/restlib.go
@@ -188,3 +188,29 @@ func SetHeaders(w http.ResponseWriter, headerMap http.Header) {
 		}
 	}
 }
+
+// RestRequestOption is an interface that marks options that can be passed to downstream REST requests.
+type RestRequestOption interface {
+	restRequestOption()
+}
+
+// RestRequestOnResult returns a RestRequestOption that can be passed to a downstream REST request.
+// The function passed in will be called immediately after a downstream response is retrieved.
+func RestRequestOnResult(f func(result *HTTPResult, err error)) RestRequestOption {
+	return onResultRestRequestOption{f}
+}
+
+type onResultRestRequestOption struct {
+	onResult func(result *HTTPResult, err error)
+}
+
+func (o onResultRestRequestOption) restRequestOption() {}
+
+// OnRestRequestResult is called from generated code when an HTTP result is retrieved.
+func OnRestRequestResult(result *HTTPResult, err error, opts []RestRequestOption) {
+	for _, opt := range opts {
+		if onResult, ok := opt.(*onResultRestRequestOption); ok {
+			onResult.onResult(result, err)
+		}
+	}
+}


### PR DESCRIPTION
In some instances, custom handler implementations require access to
more information than downstream service calls currently permit. 

Downstream service calls currently provide access to deserialised
response body on successful requests, however in some instances
the status code and headers are also required to be known.

Likewise, downstream services calls currently return an error for
unsuccessful requests, however in some instances the status code,
headers or response body are required to be known.

RestRequestOption instances can be passed into downstream REST
requests to perform custom actions:

```go
response, err := client.GetRestFooBar(ctx, &request,
    restlib.RestRequestOnResult(func(result *restlib.HTTPResult, err error) {
        // access to raw http result and error
    }))
```

To support this, generated clients subsequently change:
```go
// from
GetRestFooBar func(ctx context.Context, req *foo.GetRestFooBarRequest) 
(*foo.BarResponse, error)

// to
GetRestFooBar func(ctx context.Context, req *foo.GetRestFooBarRequest, opts ...restlib.RestRequestOption) 
(*foo.BarResponse, error)
```

Closes #105 #159