### PR TITLE
Do not generate external type aliases

### DIFF
--- a/codegen/arrai/svc_types.arrai
+++ b/codegen/arrai/svc_types.arrai
@@ -136,7 +136,7 @@ let orderedTypes = \types
                 `::\i}
             `
         }
-        ${aliases where .@item.@ != "Empty" >> $`
+        ${aliases where .@item.@ != "Empty" && !//seq.has_prefix("EXTERNAL_", .@item.@) >> $`
             // ${.typename} ...
             type ${.typename} ${go.type(.@value)}
         `::\i}


### PR DESCRIPTION
To match with existing `transforms/svc_types.sysl` generated code,
`arrai/svc_types.arrai` no longer generates 'external' types:

```go
// EXTERNAL_FooBar ...
type EXTERNAL_FooBar string
```