### PR TITLE
Fix generation using arrai

### DIFF
--- a/codegen/arrai/go.arrai
+++ b/codegen/arrai/go.arrai
@@ -125,7 +125,7 @@ let module = \module
         let pkgnames = type => .@item;
         let packages = module('apps') where .@ <: pkgnames;
         cond {
-            packages: $`${cond {seq: "[]"}}${package((packages single).@value)}.${type(1)}`,
+            packages: $`${cond {seq: "[]"}}${package((packages single).@value)}.${name(type(1))}`,
             type = ["ok"]: "",
             _: //str.title(//seq.concat(type)),
         };

--- a/codegen/arrai/svc_router.arrai
+++ b/codegen/arrai/svc_router.arrai
@@ -42,7 +42,7 @@ let go = //{./go};
     }
 
     // Config ...
-    func (s *ServiceRouter) Config() interface{} {
+    func (s *ServiceRouter) Config() validator.Validator {
         return s.gc.Config()
     }
 

--- a/codegen/arrai/svc_router.arrai
+++ b/codegen/arrai/svc_router.arrai
@@ -42,7 +42,7 @@ let go = //{./go};
     }
 
     // Config ...
-    func (s *ServiceRouter) Config() validator.Validator {
+    func (s *ServiceRouter) Config() interface{} {
         return s.gc.Config()
     }
 


### PR DESCRIPTION
The following problems presented with https://github.com/anz-bank/sysl-template

```go
// Service interface for simple
type Service interface {
	Get(ctx context.Context, req *GetRequest) (*Welcome, error)
	GetFoobarList(ctx context.Context, req *GetFoobarListRequest) (*jsonplaceholder.todosResponse, error)
}
```
There is a reference to an unexported field, that should be exported; ie `*jsonplaceholder.TodosResponse` instead of `*jsonplaceholder.todosResponse`


This is the fix to make it work

This isn't to be merged in immediately, as there is some code gen that relies on the current version of arrai and these changes might be breaking changes

