### PR TITLE
Update default callback to implement core.RestGenCallback interface

### DIFF
--- a/common/defaultcallback.go
+++ b/common/defaultcallback.go
@@ -53,3 +53,7 @@ func (g Callback) HandleError(ctx context.Context, w http.ResponseWriter, kind K
 func (g Callback) DownstreamTimeoutContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, g.DownstreamTimeout)
 }
+
+func (g Callback) MapError(ctx context.Context, err error) *HTTPError {
+	return nil
+}

--- a/common/defaultcallback.go
+++ b/common/defaultcallback.go
@@ -44,10 +44,7 @@ func (g Callback) Config() interface{} {
 
 func (g Callback) HandleError(ctx context.Context, w http.ResponseWriter, kind Kind, message string, cause error) {
 	se := CreateError(ctx, kind, message, cause)
-
-	httpError := MapError(ctx, se)
-
-	httpError.WriteError(ctx, w)
+	g.MapError(ctx, se).WriteError(ctx, w)
 }
 
 func (g Callback) DownstreamTimeoutContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/common/defaultcallback.go
+++ b/common/defaultcallback.go
@@ -55,5 +55,6 @@ func (g Callback) DownstreamTimeoutContext(ctx context.Context) (context.Context
 }
 
 func (g Callback) MapError(ctx context.Context, err error) *HTTPError {
-	return nil
+	httpErr := MapError(ctx, err)
+	return &httpErr
 }


### PR DESCRIPTION
Updates the default callback to implement interface defined [here](https://github.com/anz-bank/sysl-go/blob/eedeba910dcdb036374e966dab0d53f1cc5fbc39/core/callback.go#L11)