### PR TITLE
Fix generation of sysl.json files in testdata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,8 @@ SYSL_GO_ROOT=github.com/anz-bank/sysl-go
 MIGRATE=migrate
 
 define run-arrai
+$(eval NAME := $(shell echo $< | tr '[:upper:]' '[:lower:]'))
+sysl pb --mode=json $(TEST_IN_DIR)/$(NAME)/$(NAME).sysl > $(TEST_IN_DIR)/$(NAME)/sysl.json
 $(ARRAI_SERVICE_ROOT)/service.arrai \
 	$(SYSL_GO_ROOT)/$(TEST_OUT_DIR) $(TEST_IN_DIR)/$</sysl.json \
 	$< $(MIGRATE) | tar xf - -C $(TEST_OUT_DIR)/$<

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 
 all: gen test check-coverage arrai-nodiff lint tidy ## Tests, lints and checks coverage
 
-clean:  ## Remove generated files
-
 .PHONY: all clean
 
 # -- Lint ----------------------------------------------------------------------
@@ -33,6 +31,7 @@ coverage: test  ## Show test coverage in your browser
 
 clean:
 	rm -f $(COVERFILE)
+	rm -f $(patsubst %,codegen/testdata/%/sysl.json,$(targets))
 
 CHECK_COVERAGE = awk -F '[ \t%]+' '/^total:/ && $$3 < $(COVERAGE) {exit 1}'
 FAIL_COVERAGE = { echo '$(COLOUR_RED)FAIL - Coverage below $(COVERAGE)%$(COLOUR_NORMAL)'; exit 1; }
@@ -129,8 +128,6 @@ simple.groups = rest-app
 
 simplegrpc.app = SimpleGrpc
 simplegrpc.groups = grpc-app
-
-.PRECIOUS: $(patsubst %,codegen/testdata/%/sysl.json,$(targets))
 
 codegen/testdata/%/sysl.json: codegen/testdata/%/*.sysl
 	sysl pb --mode=json --root $(TEST_IN_DIR) $*/$*.sysl > $@ || rm -f $@


### PR DESCRIPTION
Fixes #177 

Currently make doesn't regenerate `testdata/*/sysl.json` from `testdata/*/*.sysl`, meaning tests don't necessarily run against the latest generated code following changes to the Sysl specs.

This solution is not good Makefile style, but it fixes the problem. The whole make system in sysl-go needs an overhaul, so I'm not keen to take on the whole thing for this fix.