### PR TITLE
Allow downstream api to return sequences.

### DIFF
--- a/codegen/arrai/go.arrai
+++ b/codegen/arrai/go.arrai
@@ -127,7 +127,7 @@ let module = \module
         cond {
             packages: $`${cond {seq: "[]"}}${package((packages single).@value)}.${type(1)}`,
             type = ["ok"]: "",
-            _: //str.title(//seq.concat(type)),
+            _: $`${cond{seq: `[]`}}` ++ //str.title(//seq.concat(type)),
         };
 
     let targetApp = \target
@@ -157,7 +157,7 @@ let module = \module
         let method = methodName(ep);
         let grpc = cond {'gRPC' <: sysl.patterns(dep): `, opts ...grpc.CallOption`};
         $`${method} func(ctx context.Context, req *${package}.${method}Request${grpc}) (${
-            let typed = sysl.endpoint.normalReturns(ep) >> $`*${package}.${.type >> name(.)::}`;
+            let typed = sysl.endpoint.normalReturns(ep) >> $`*${cond{.seq: `[]`}}${package}.${.type >> name(.)::}`;
             let untyped = sysl.endpoint.untypedReturns(ep) >> `*http.Header`;
             typed ++ untyped ++ ["error"]
         ::, })`;

--- a/codegen/testdata/simple/downstream.sysl
+++ b/codegen/testdata/simple/downstream.sysl
@@ -4,7 +4,7 @@ Downstream "Downstream System" [package="downstream"]:
     /service-docs:
         GET:
             | Return whole service docs 
-            return ok <: ServiceDoc
+            return ok <: sequence of ServiceDoc
             return error <: status
 
     !type ServiceDoc:

--- a/codegen/testdata/simple/simple.sysl
+++ b/codegen/testdata/simple/simple.sysl
@@ -17,7 +17,7 @@ Simple "Simple Server" [package="simple"]:
 
     /raw/states:
         GET:
-            return ok <: str
+            return ok <: sequence of Status
 
     /raw/{id<:string}/states [~vars_in_url_name]:
         GET:

--- a/codegen/tests/downstream/service.go
+++ b/codegen/tests/downstream/service.go
@@ -14,7 +14,7 @@ import (
 
 // Service interface for Downstream
 type Service interface {
-	GetServiceDocsList(ctx context.Context, req *GetServiceDocsListRequest) (*ServiceDoc, error)
+	GetServiceDocsList(ctx context.Context, req *GetServiceDocsListRequest) (*[]ServiceDoc, error)
 }
 
 // Client for Downstream API
@@ -29,9 +29,9 @@ func NewClient(client *http.Client, serviceURL string) *Client {
 }
 
 // GetServiceDocsList ...
-func (s *Client) GetServiceDocsList(ctx context.Context, req *GetServiceDocsListRequest) (*ServiceDoc, error) {
+func (s *Client) GetServiceDocsList(ctx context.Context, req *GetServiceDocsListRequest) (*[]ServiceDoc, error) {
 	required := []string{}
-	var okResponse ServiceDoc
+	var okResponse []ServiceDoc
 	var errorResponse Status
 	u, err := url.Parse(fmt.Sprintf("%s/service-docs", s.url))
 	if err != nil {
@@ -50,7 +50,7 @@ func (s *Client) GetServiceDocsList(ctx context.Context, req *GetServiceDocsList
 	if result.HTTPResponse.StatusCode == http.StatusUnauthorized {
 		return nil, common.CreateDownstreamError(ctx, common.DownstreamUnauthorizedError, result.HTTPResponse, result.Body, nil)
 	}
-	OkServiceDocResponse, ok := result.Response.(*ServiceDoc)
+	OkServiceDocResponse, ok := result.Response.(*[]ServiceDoc)
 	if ok {
 		valErr := validator.Validate(OkServiceDocResponse)
 		if valErr != nil {

--- a/codegen/tests/downstream/serviceinterface.go
+++ b/codegen/tests/downstream/serviceinterface.go
@@ -21,7 +21,7 @@ type GetServiceDocsListClient struct {
 
 // ServiceInterface for Downstream
 type ServiceInterface struct {
-	GetServiceDocsList func(ctx context.Context, req *GetServiceDocsListRequest, client GetServiceDocsListClient) (*ServiceDoc, error)
+	GetServiceDocsList func(ctx context.Context, req *GetServiceDocsListRequest, client GetServiceDocsListClient) (*[]ServiceDoc, error)
 }
 
 // DownstreamConfig for Downstream

--- a/codegen/tests/simple/service.go
+++ b/codegen/tests/simple/service.go
@@ -24,7 +24,7 @@ type Service interface {
 	GetOopsList(ctx context.Context, req *GetOopsListRequest) (*Response, error)
 	GetRawList(ctx context.Context, req *GetRawListRequest) (*Str, error)
 	GetRawIntList(ctx context.Context, req *GetRawIntListRequest) (*Integer, error)
-	GetRawStatesList(ctx context.Context, req *GetRawStatesListRequest) (*Str, error)
+	GetRawStatesList(ctx context.Context, req *GetRawStatesListRequest) (*[]Status, error)
 	GetRawIdStatesList(ctx context.Context, req *GetRawIdStatesListRequest) (*Str, error)
 	GetRawStates2List(ctx context.Context, req *GetRawStates2ListRequest) (*Str, error)
 	GetSimpleAPIDocsList(ctx context.Context, req *GetSimpleAPIDocsListRequest) (*deps.ApiDoc, error)
@@ -290,9 +290,9 @@ func (s *Client) GetRawIntList(ctx context.Context, req *GetRawIntListRequest) (
 }
 
 // GetRawStatesList ...
-func (s *Client) GetRawStatesList(ctx context.Context, req *GetRawStatesListRequest) (*Str, error) {
+func (s *Client) GetRawStatesList(ctx context.Context, req *GetRawStatesListRequest) (*[]Status, error) {
 	required := []string{}
-	var okResponse Str
+	var okResponse []Status
 	u, err := url.Parse(fmt.Sprintf("%s/raw/states", s.url))
 	if err != nil {
 		return nil, common.CreateError(ctx, common.InternalError, "failed to parse url", err)
@@ -306,14 +306,14 @@ func (s *Client) GetRawStatesList(ctx context.Context, req *GetRawStatesListRequ
 	if result.HTTPResponse.StatusCode == http.StatusUnauthorized {
 		return nil, common.CreateDownstreamError(ctx, common.DownstreamUnauthorizedError, result.HTTPResponse, result.Body, nil)
 	}
-	OkStrResponse, ok := result.Response.(*Str)
+	OkStatusResponse, ok := result.Response.(*[]Status)
 	if ok {
-		valErr := validator.Validate(OkStrResponse)
+		valErr := validator.Validate(OkStatusResponse)
 		if valErr != nil {
 			return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, valErr)
 		}
 
-		return OkStrResponse, nil
+		return OkStatusResponse, nil
 	}
 
 	return nil, common.CreateDownstreamError(ctx, common.DownstreamUnexpectedResponseError, result.HTTPResponse, result.Body, nil)

--- a/codegen/tests/simple/servicehandler.go
+++ b/codegen/tests/simple/servicehandler.go
@@ -409,7 +409,7 @@ func (s *ServiceHandler) GetRawStatesListHandler(w http.ResponseWriter, r *http.
 
 	client := GetRawStatesListClient{}
 
-	str, err := s.serviceInterface.GetRawStatesList(ctx, &req, client)
+	status, err := s.serviceInterface.GetRawStatesList(ctx, &req, client)
 	if err != nil {
 
 		common.HandleError(ctx, w, common.DownstreamUnexpectedResponseError, "Downstream failure", err, s.genCallback.MapError)
@@ -421,7 +421,7 @@ func (s *ServiceHandler) GetRawStatesListHandler(w http.ResponseWriter, r *http.
 		headermap.Set("Content-Type", "application/json")
 	}
 	restlib.SetHeaders(w, headermap)
-	restlib.SendHTTPResponse(w, httpstatus, str)
+	restlib.SendHTTPResponse(w, httpstatus, status)
 }
 
 // GetRawIdStatesListHandler ...
@@ -620,7 +620,6 @@ func (s *ServiceHandler) PostStuffHandler(w http.ResponseWriter, r *http.Request
 	ctx := common.RequestHeaderToContext(r.Context(), r.Header)
 	ctx = common.RespHeaderAndStatusToContext(ctx, make(http.Header), http.StatusOK)
 	var req PostStuffRequest
-
 	decoder := json.NewDecoder(r.Body)
 	decodeErr := decoder.Decode(&req.Request)
 	if decodeErr != nil {

--- a/codegen/tests/simple/serviceinterface.go
+++ b/codegen/tests/simple/serviceinterface.go
@@ -23,7 +23,7 @@ func NewDefaultSimpleImpl() *DefaultSimpleImpl {
 // GetApiDocsList Client
 type GetApiDocsListClient struct {
 	GetApiDocsList     func(ctx context.Context, req *deps.GetApiDocsListRequest) (*deps.ApiDoc, error)
-	GetServiceDocsList func(ctx context.Context, req *downstream.GetServiceDocsListRequest) (*downstream.ServiceDoc, error)
+	GetServiceDocsList func(ctx context.Context, req *downstream.GetServiceDocsListRequest) (*[]downstream.ServiceDoc, error)
 }
 
 // GetGetSomeBytesList Client
@@ -95,7 +95,7 @@ type ServiceInterface struct {
 	GetOopsList               func(ctx context.Context, req *GetOopsListRequest, client GetOopsListClient) (*Response, error)
 	GetRawList                func(ctx context.Context, req *GetRawListRequest, client GetRawListClient) (*Str, error)
 	GetRawIntList             func(ctx context.Context, req *GetRawIntListRequest, client GetRawIntListClient) (*Integer, error)
-	GetRawStatesList          func(ctx context.Context, req *GetRawStatesListRequest, client GetRawStatesListClient) (*Str, error)
+	GetRawStatesList          func(ctx context.Context, req *GetRawStatesListRequest, client GetRawStatesListClient) (*[]Status, error)
 	GetRawIdStatesList        func(ctx context.Context, req *GetRawIdStatesListRequest, client GetRawIdStatesListClient) (*Str, error)
 	GetRawStates2List         func(ctx context.Context, req *GetRawStates2ListRequest, client GetRawStates2ListClient) (*Str, error)
 	GetSimpleAPIDocsList      func(ctx context.Context, req *GetSimpleAPIDocsListRequest, client GetSimpleAPIDocsListClient) (*deps.ApiDoc, error)

--- a/codegen/tests/simple/simple_test.go
+++ b/codegen/tests/simple/simple_test.go
@@ -646,7 +646,7 @@ func TestBuildDownstreamClients(t *testing.T) {
 	require.NotNil(t, handlers.downstreamClient)
 }
 
-func TestApiDocsReturnsSequence(t *testing.T) {
+func TestApiDocsReturnsSequenceOfDownstreamType(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		depsSeq := `[{"openapi":"1","swagger":"2"},{"openapi":"y","swagger":"n"}]`
 		w.WriteHeader(200)
@@ -662,6 +662,26 @@ func TestApiDocsReturnsSequence(t *testing.T) {
 
 	req := GetApiDocsListRequest{}
 	sequenceRes, err := c.GetApiDocsList(context.Background(), &req)
+	require.NoError(t, err)
+	require.True(t, len(*sequenceRes) > 0)
+}
+
+func TestApiDocsReturnsSequence(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		depsSeq := `[{"statusField":"open"}]`
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(depsSeq))
+	}))
+	client := server.Client()
+	defer server.Close()
+
+	c := Client{
+		client: client,
+		url:    server.URL,
+	}
+
+	req := GetRawStatesListRequest{}
+	sequenceRes, err := c.GetRawStatesList(context.Background(), &req)
 	require.NoError(t, err)
 	require.True(t, len(*sequenceRes) > 0)
 }


### PR DESCRIPTION
Generated go code was incorrect when a sysl endpoint returned a sequence of sysl types defined in the same app. The change fixes that:

1. Arrai transform fixes.
2. Test cases updates.
3. Generated go code updated.

Fixes #175 