### PR TITLE
Make generate-tag use REPO_ACCESS_TOKEN so that CI runs

### DIFF
--- a/.github/workflows/generate-tag.yaml
+++ b/.github/workflows/generate-tag.yaml
@@ -20,5 +20,5 @@ jobs:
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@1.19.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
           WITH_V: true


### PR DESCRIPTION
The docker runner isn't working because GITHUB_TOKEN doesn't trigger ci events