### PR TITLE
Make json validate optional/configurable.

### DIFF
--- a/codegen/arrai/svc_types.arrai
+++ b/codegen/arrai/svc_types.arrai
@@ -11,7 +11,7 @@ let fieldJsonTag = \type \key
     };
 
 \(:app, :endpoints, :module, ...)
-    let entities = orderedTypes(app('types') where !sysl.patterns(.@value) && {"tuple", "relation"} & (.@value => .@));
+    let entities = orderedTypes(app('types') where !({"error"} & sysl.patterns(.@value)) && {"tuple", "relation"} & (.@value => .@));
     let aliases = orderedTypes(app('types') where !({'oneof', 'tuple', 'relation'} & (.@value => .@)));
     $`
         ${go.prelude(app, {})}
@@ -50,7 +50,7 @@ let fieldJsonTag = \type \key
                 }
                 ${
                     let optParams = entity('attrDefs') where sysl.isPtr(.@value) orderby .@ >> .@value;
-                    cond {optParams: $`func (t *${typename}) UnmarshalJSON(data []byte) error {
+                    cond {{"validate"} & patterns && optParams: $`func (t *${typename}) UnmarshalJSON(data []byte) error {
                         inner := struct {
                             ${entity('attrDefs') orderby .@ >> \(@: key, @value: attrDef)
                                 $'${go.name(key)} ${cond { !sysl.isPtr(attrDef) : '*', _ : ''}}${go.type(attrDef)} `json:"${fieldJsonTag(attrDef, key)::,},omitempty"`'

--- a/codegen/arrai/sysl.arrai
+++ b/codegen/arrai/sysl.arrai
@@ -5,7 +5,7 @@ let app = (
         ((app('endpoints') where .@value('name').s = epname) single).@value,
 );
 
-let isPtr = \t t('opt')?:false && !({"sequence", "set"} & (t => .@));
+let isPtr = \t t('opt')?:false;
 
 let endpoint =
     let calls = \ep

--- a/codegen/testdata/simple/simple.sysl
+++ b/codegen/testdata/simple/simple.sysl
@@ -128,7 +128,7 @@ Simple "Simple Server" [package="simple"]:
     !type Status:
         statusField <: string
 
-    !type PostRequest:
+    !type PostRequest [~validate]:
         Bt <: bool?:
             @json_tag = "Bt"
         Dt <: datetime:


### PR DESCRIPTION
Allow sysl-go adoption teams to opt out of json validation of sysl types.

1. Arrai transform changes.

Fixes #182 