### PR TITLE
ProvisionRestResult implementation

### DIFF
--- a/codegen/arrai/svc_service.arrai
+++ b/codegen/arrai/svc_service.arrai
@@ -71,6 +71,7 @@ let sysl = //{./sysl};
                     cond {"ok" <: retvars: "&okResponse", _: "nil"}}, ${
                     cond {"error" <: retvars: "&errorResponse", _: "nil"}})`
             }
+            restlib.OnRestResultHTTPResult(ctx, result, err)
             if err != nil {
                 ${
                     let downstreamUnavailable = $`

--- a/codegen/tests/deps/service.go
+++ b/codegen/tests/deps/service.go
@@ -40,6 +40,7 @@ func (s *Client) GetApiDocsList(ctx context.Context, req *GetApiDocsListRequest)
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, &errorResponse)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		response, ok := err.(*restlib.HTTPResult)
 		if !ok {
@@ -73,6 +74,7 @@ func (s *Client) GetSuccessList(ctx context.Context, req *GetSuccessListRequest)
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, nil, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Deps <- GET "+u.String(), err)
 	}

--- a/codegen/tests/downstream/service.go
+++ b/codegen/tests/downstream/service.go
@@ -39,6 +39,7 @@ func (s *Client) GetServiceDocsList(ctx context.Context, req *GetServiceDocsList
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, &errorResponse)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		response, ok := err.(*restlib.HTTPResult)
 		if !ok {

--- a/codegen/tests/simple/service.go
+++ b/codegen/tests/simple/service.go
@@ -53,6 +53,7 @@ func (s *Client) GetApiDocsList(ctx context.Context, req *GetApiDocsListRequest)
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -83,6 +84,7 @@ func (s *Client) GetGetSomeBytesList(ctx context.Context, req *GetGetSomeBytesLi
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -112,6 +114,7 @@ func (s *Client) GetJustOkAndJustErrorList(ctx context.Context, req *GetJustOkAn
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, nil, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -131,6 +134,7 @@ func (s *Client) GetJustReturnErrorList(ctx context.Context, req *GetJustReturnE
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, nil, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -150,6 +154,7 @@ func (s *Client) GetJustReturnOkList(ctx context.Context, req *GetJustReturnOkLi
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, nil, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -170,6 +175,7 @@ func (s *Client) GetOkTypeAndJustErrorList(ctx context.Context, req *GetOkTypeAn
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -201,6 +207,7 @@ func (s *Client) GetOopsList(ctx context.Context, req *GetOopsListRequest) (*Res
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, &errorResponse)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		response, ok := err.(*restlib.HTTPResult)
 		if !ok {
@@ -239,6 +246,7 @@ func (s *Client) GetRawList(ctx context.Context, req *GetRawListRequest) (*Str, 
 
 	u.RawQuery = q.Encode()
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -269,6 +277,7 @@ func (s *Client) GetRawIntList(ctx context.Context, req *GetRawIntListRequest) (
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -299,6 +308,7 @@ func (s *Client) GetRawStatesList(ctx context.Context, req *GetRawStatesListRequ
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -329,6 +339,7 @@ func (s *Client) GetRawIdStatesList(ctx context.Context, req *GetRawIdStatesList
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -359,6 +370,7 @@ func (s *Client) GetRawStates2List(ctx context.Context, req *GetRawStates2ListRe
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -389,6 +401,7 @@ func (s *Client) GetSimpleAPIDocsList(ctx context.Context, req *GetSimpleAPIDocs
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -435,6 +448,7 @@ func (s *Client) GetStuffList(ctx context.Context, req *GetStuffListRequest) (*S
 
 	u.RawQuery = q.Encode()
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "GET", u.String(), nil, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- GET "+u.String(), err)
 	}
@@ -465,6 +479,7 @@ func (s *Client) PostStuff(ctx context.Context, req *PostStuffRequest) (*Str, er
 	}
 
 	result, err := restlib.DoHTTPRequest(ctx, s.client, "POST", u.String(), req.Request, required, &okResponse, nil)
+	restlib.OnRestResultHTTPResult(ctx, result, err)
 	if err != nil {
 		return nil, common.CreateError(ctx, common.DownstreamUnavailableError, "call failed: Simple <- POST "+u.String(), err)
 	}

--- a/restlib/restlib.go
+++ b/restlib/restlib.go
@@ -193,3 +193,28 @@ func SetHeaders(w http.ResponseWriter, headerMap http.Header) {
 		}
 	}
 }
+
+// OnRestResultHTTPResult is called from generated code when an HTTP result is retrieved.
+func OnRestResultHTTPResult(ctx context.Context, result *HTTPResult, err error) {
+	var restResult *common.RestResult = nil
+	if result != nil && result.HTTPResponse != nil {
+		restResult = &common.RestResult{
+			StatusCode: result.HTTPResponse.StatusCode,
+			Headers:    result.HTTPResponse.Header,
+			Body:       result.Body,
+		}
+	}
+	OnRestResult(ctx, restResult, err)
+}
+
+// OnRestResult method will be called from tests as we don't expose the HTTPResult itself
+func OnRestResult(ctx context.Context, result *common.RestResult, err error) {
+	raw := ctx.Value(common.RestResultContextKey{})
+	if raw == nil {
+		return
+	}
+	target := raw.(*common.RestResult)
+	target.Body = result.Body
+	target.Headers = result.Headers
+	target.StatusCode = result.StatusCode
+}

--- a/restlib/restlib_test.go
+++ b/restlib/restlib_test.go
@@ -283,3 +283,31 @@ func TestSendHTTPResponseContentTypeImage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte{1, 2}, b)
 }
+
+func TestRestResultContextWithoutProvision(t *testing.T) {
+	restResult := &common.RestResult{
+		StatusCode: 200,
+		Headers:    map[string][]string{"Accept": {"Json"}},
+		Body:       []byte("Here is a string...."),
+	}
+	ctx := context.Background()
+	OnRestResult(ctx, restResult, nil)
+	restResultFromCtx := common.GetRestResult(ctx)
+	require.Nil(t, restResultFromCtx)
+}
+
+func TestRestResultContextWithProvision(t *testing.T) {
+	restResult := &common.RestResult{
+		StatusCode: 200,
+		Headers:    map[string][]string{"Accept": {"Json"}},
+		Body:       []byte("Here is a string...."),
+	}
+	ctx := context.Background()
+	ctx = common.ProvisionRestResult(ctx)
+	OnRestResult(ctx, restResult, nil)
+	restResultFromCtx := common.GetRestResult(ctx)
+	require.NotNil(t, restResultFromCtx)
+	require.Equal(t, restResult.StatusCode, restResultFromCtx.StatusCode)
+	require.Equal(t, restResult.Headers, restResultFromCtx.Headers)
+	require.Equal(t, restResult.Body, restResultFromCtx.Body)
+}


### PR DESCRIPTION
Custom handler implementations in some instances require access to
more information than downstream service calls currently permit. This
can include the status code, headers or body in the instance that a
non-successful response was returned.

Custom code can ProvisionRestResult and retrive the RestResult after the downstream call
Generated code will set the HTTP result as the RestResult

close #105 #159