### PR TITLE
Cleanup linter diagnostics

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,10 +15,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Run golangci-lint v1.29.0
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.29.0
 
   test:
     name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run golangci-lint 1.29.0
         uses: golangci/golangci-lint-action@v2
         with:
-          golangci_lint_version: 1.29.0
+          version: 1.29.0
 
   test:
     name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
 
   test:
     name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Run golangci-lint 1.27.0
-        uses: actions-contrib/golangci-lint@v1
+      - name: Run golangci-lint 1.29.0
+        uses: golangci/golangci-lint-action@v2
         with:
-          golangci_lint_version: 1.27.0
+          golangci_lint_version: 1.29.0
 
   test:
     name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Run golangci-lint 1.23.8
+      - name: Run golangci-lint 1.27.0
         uses: actions-contrib/golangci-lint@v1
         with:
           golangci_lint_version: 1.23.8

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run golangci-lint 1.27.0
         uses: actions-contrib/golangci-lint@v1
         with:
-          golangci_lint_version: 1.23.8
+          golangci_lint_version: 1.27.0
 
   test:
     name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Run golangci-lint 1.29.0
+      - name: Run golangci-lint v1.29.0
         uses: golangci/golangci-lint-action@v2
         with:
-          version: 1.29.0
+          version: v1.29.0
 
   test:
     name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,20 +6,58 @@ linters-settings:
     line-length: 180
 
 linters:
-  enable-all: true
-  disable:
-    - dupl
-    - gochecknoglobals
-    - godot
-    - goerr113
-    - gomnd # Ignore magic as it seems to produce too much noise for this codebase
-    - gosec
-    - lll
-    - nestif
-    - stylecheck
-    - testpackage
-    - wsl
-    - unused
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - errcheck
+    - funlen
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godox
+    - gofmt
+    - goimports
+    - golint
+    - gomodguard
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - maligned
+    - misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - varcheck
+    - whitespace
+
+    # Omitted as at 1.27.0.
+    # - dupl
+    # - gochecknoglobals
+    # - godot
+    # - goerr113
+    # - gomnd
+    # - gosec
+    # - lll
+    # - nestif
+    # - stylecheck
+    # - testpackage
+    # - wsl
+    # - unused
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    # - asciicheck # not available in CI, same version (1.27.0)!
+    # - asciicheck # not available in CI version of golangci-lint
     - bodyclose
     - deadcode
     - depguard
@@ -20,12 +20,12 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    # - godot # not available in CI, same version (1.27.0)!
+    # - godot # not available in CI version of golangci-lint
     - godox
     - gofmt
     - goimports
     - golint
-    - gomodguard
+    # - gomodguard # not available in CI version of golangci-lint
     - goprintffuncname
     - gosimple
     - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 service:
-  golangci-lint-version: 1.27.0
+  golangci-lint-version: 1.29.0
 
 linters-settings:
   lll:
@@ -8,7 +8,7 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    # - asciicheck # not available in CI version of golangci-lint
+    - asciicheck
     - bodyclose
     - deadcode
     - depguard
@@ -20,12 +20,12 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    # - godot # not available in CI version of golangci-lint
+    - godot
     - godox
     - gofmt
     - goimports
     - golint
-    # - gomodguard # not available in CI version of golangci-lint
+    - gomodguard
     - goprintffuncname
     - gosimple
     - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+service:
+  golangci-lint-version: 1.27.0
+
 linters-settings:
   lll:
     line-length: 180

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - asciicheck
+    # - asciicheck # not available in CI, same version (1.27.0)!
     - bodyclose
     - deadcode
     - depguard
@@ -20,6 +20,7 @@ linters:
     - goconst
     - gocritic
     - gocyclo
+    # - godot # not available in CI, same version (1.27.0)!
     - godox
     - gofmt
     - goimports
@@ -45,19 +46,18 @@ linters:
     - varcheck
     - whitespace
 
-    # Omitted as at 1.27.0.
-    # - dupl
-    # - gochecknoglobals
-    # - godot
-    # - goerr113
-    # - gomnd
-    # - gosec
-    # - lll
-    # - nestif
-    # - stylecheck
-    # - testpackage
-    # - wsl
-    # - unused
+  # disable: # as at 1.27.0
+  #   - dupl
+  #   - gochecknoglobals
+  #   - goerr113
+  #   - gomnd
+  #   - gosec
+  #   - lll
+  #   - nestif
+  #   - stylecheck
+  #   - testpackage
+  #   - wsl
+  #   - unused
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,9 +7,16 @@ linters:
   disable:
     - dupl
     - gochecknoglobals
-    - wsl
-    - lll
+    - godot
+    - goerr113
     - gomnd # Ignore magic as it seems to produce too much noise for this codebase
+    - gosec
+    - lll
+    - nestif
+    - stylecheck
+    - testpackage
+    - wsl
+    - unused
 
 issues:
   exclude-rules:

--- a/codegen/tests/callback/gen_callback.go
+++ b/codegen/tests/callback/gen_callback.go
@@ -4,7 +4,7 @@ import (
 	"context"
 )
 
-// GenCallback callbacks used by the generated code
+// GenCallback callbacks are used by the generated code.
 type GenCallback interface {
 	DownstreamTimeoutContext(ctx context.Context) (context.Context, context.CancelFunc)
 }

--- a/common/corerequestcontext.go
+++ b/common/corerequestcontext.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Deprecated: Use ServerParams.WithPkgLogger instead
+// Deprecated: Use ServerParams.WithPkgLogger instead.
 func GetLogEntryFromContext(ctx context.Context) *logrus.Entry {
 	core := getCoreContext(ctx)
 	if core == nil {
@@ -21,7 +21,7 @@ func GetLogEntryFromContext(ctx context.Context) *logrus.Entry {
 	return core.entry
 }
 
-// Deprecated: Use ServerParams.WithPkgLogger instead
+// Deprecated: Use ServerParams.WithPkgLogger instead.
 func GetLoggerFromContext(ctx context.Context) *logrus.Logger {
 	core := getCoreContext(ctx)
 	if core == nil {
@@ -55,18 +55,18 @@ type RestResult struct {
 	Body       []byte
 }
 
-// LoggerToContext create a new context containing the logger
-// Deprecated: Use ServerParams.WithPkgLogger instead
+// LoggerToContext creates a new context containing the logger.
+// Deprecated: Use ServerParams.WithPkgLogger instead.
 func LoggerToContext(ctx context.Context, logger *logrus.Logger, entry *logrus.Entry) context.Context {
 	return context.WithValue(ctx, coreRequestContextKey{}, &coreRequestContext{logger, entry})
 }
 
-// RequestHeaderToContext create a new context containing the request header
+// RequestHeaderToContext creates a new context containing the request header.
 func RequestHeaderToContext(ctx context.Context, header http.Header) context.Context {
 	return context.WithValue(ctx, reqHeaderContextKey{}, &reqHeaderContext{header})
 }
 
-// RequestHeaderFromContext retrieve the request header from the context
+// RequestHeaderFromContext retrieves the request header from the context.
 func RequestHeaderFromContext(ctx context.Context) http.Header {
 	reqHeader := getReqHeaderContext(ctx)
 
@@ -76,12 +76,12 @@ func RequestHeaderFromContext(ctx context.Context) http.Header {
 	return reqHeader.header
 }
 
-// RespHeaderAndStatusToContext create a new context containing the response header and status
+// RespHeaderAndStatusToContext creates a new context containing the response header and status.
 func RespHeaderAndStatusToContext(ctx context.Context, header http.Header, status int) context.Context {
 	return context.WithValue(ctx, respHeaderAndStatusContextKey{}, &respHeaderAndStatusContext{header, status})
 }
 
-// RespHeaderAndStatusFromContext retrieve response header and status from the context
+// RespHeaderAndStatusFromContext retrieves response header and status from the context.
 func RespHeaderAndStatusFromContext(ctx context.Context) (header http.Header, status int) {
 	respHeaderAndStatus := getRespHeaderAndStatusContext(ctx)
 
@@ -180,13 +180,15 @@ func (t *tempRoundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 type RestResultContextKey struct{}
 
-// Provision within the context the ability to retrieve the result of a rest request
+// ProvisionRestResult provisions within the context the ability to retrieve the
+// result of a rest request.
 func ProvisionRestResult(ctx context.Context) context.Context {
 	return context.WithValue(ctx, RestResultContextKey{}, &RestResult{})
 }
 
-// Get the result of the most recent rest request. The context must be provisioned prior to the
-// request taking place with a call to ProvisionRestResult
+// GetRestResult gets the result of the most recent rest request. The context
+// must be provisioned prior to the request taking place with a call to
+// ProvisionRestResult.
 func GetRestResult(ctx context.Context) *RestResult {
 	raw := ctx.Value(RestResultContextKey{})
 	if raw == nil {

--- a/common/custom_error.go
+++ b/common/custom_error.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/anz-bank/pkg/log"
@@ -19,7 +20,7 @@ func (e CustomError) HTTPError(ctx context.Context) *HTTPError {
 	httpStatus, err := strconv.Atoi(httpStatusString)
 	if err != nil {
 		log.Error(ctx, err, fmt.Sprintf("invalid http_status: %s for: %s", httpStatusString, e["name"]))
-		httpStatus = 500 //nolint: // TODO: use constant for internal server error
+		httpStatus = http.StatusInternalServerError
 	}
 	httpCode := getOrDefault(e, "http_code", "")
 	httpMessage := getOrDefault(e, "http_message", "")

--- a/common/sensitivestring.go
+++ b/common/sensitivestring.go
@@ -39,7 +39,7 @@ func (s *SensitiveString) UnmarshalYAML(unmarshal func(interface{}) error) error
 	return nil
 }
 
-// Note, this one needs to be an object receiver NOT a pointer receiver
+// Note, this one needs to be an object receiver NOT a pointer receiver.
 func (s SensitiveString) MarshalYAML() (interface{}, error) {
 	return s.String(), nil
 }

--- a/common/timeout.go
+++ b/common/timeout.go
@@ -13,7 +13,7 @@ import (
 	"github.com/anz-bank/pkg/log"
 )
 
-// Timeout is a middleware that cancels ctx after a given timeout or call a special handler on timeout
+// Timeout is a middleware that cancels ctx after a given timeout or call a special handler on timeout.
 func Timeout(ctx context.Context, timeout time.Duration, timeoutHandler http.Handler) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return TimeoutHandler(ctx, next, timeout, timeoutHandler)

--- a/common/tracability.go
+++ b/common/tracability.go
@@ -19,7 +19,7 @@ type requestID struct {
 
 const traceIDLogField = "traceid"
 
-// Injects a traceId UUID into the request context
+// Injects a traceId UUID into the request context.
 func TraceabilityMiddleware(ctx context.Context) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ type DefaultConfig struct {
 // LoadConfig reads and validates a configuration loaded from file.
 // file: the path to the yaml-encoded config file
 // defaultConfig: a pointer to the default config struct to populate
-// customConfig: a pointer to the custom config struct to populate
+// customConfig: a pointer to the custom config struct to populate.
 func LoadConfig(file string, defaultConfig *DefaultConfig, customConfig interface{}) error {
 	b, err := ioutil.ReadFile(file)
 	if err != nil {

--- a/config/gen_code.go
+++ b/config/gen_code.go
@@ -4,13 +4,13 @@ import (
 	"time"
 )
 
-// GenCodeConfig struct
+// GenCodeConfig struct.
 type GenCodeConfig struct {
 	Upstream   UpstreamConfig `yaml:"upstream"`
 	Downstream interface{}    `yaml:"downstream"`
 }
 
-// UpstreamConfig struct
+// UpstreamConfig struct.
 type UpstreamConfig struct {
 	ContextTimeout time.Duration          `yaml:"contextTimeout" validate:"nonnil"`
 	HTTP           CommonHTTPServerConfig `yaml:"http"`

--- a/config/grpc.go
+++ b/config/grpc.go
@@ -22,7 +22,7 @@ func ExtractGrpcServerOptions(cfg *CommonServerConfig) ([]grpc.ServerOption, err
 	return []grpc.ServerOption{grpc.Creds(creds)}, nil
 }
 
-// CommonGRPCDownstreamData collects all the client gRPC configuration
+// CommonGRPCDownstreamData collects all the client gRPC configuration.
 type CommonGRPCDownstreamData struct {
 	ServiceAddress string     `yaml:"serviceAddress"`
 	TLS            *TLSConfig `yaml:"tls"`

--- a/config/http.go
+++ b/config/http.go
@@ -27,14 +27,14 @@ func DefaultCommonDownstreamData() *CommonDownstreamData {
 	}
 }
 
-// CommonDownstreamData collects all the client http configuration
+// CommonDownstreamData collects all the client http configuration.
 type CommonDownstreamData struct {
 	ServiceURL      string        `yaml:"serviceURL"`
 	ClientTransport Transport     `yaml:"clientTransport"`
 	ClientTimeout   time.Duration `yaml:"clientTimeout" validate:"timeout=1ms:60s"`
 }
 
-// Transport is used to initialise DefaultHTTPTransport
+// Transport is used to initialise DefaultHTTPTransport.
 type Transport struct {
 	Dialer                Dialer `yaml:"dialer"`
 	MaxIdleConns          int
@@ -46,7 +46,7 @@ type Transport struct {
 	UseProxy              bool       `yaml:"useProxy"`
 }
 
-// Dialer is part of the Transport struct
+// Dialer is part of the Transport struct.
 type Dialer struct {
 	Timeout   time.Duration `yaml:"timeout"`
 	KeepAlive time.Duration `yaml:"keepAlive"`
@@ -104,7 +104,7 @@ func proxyHandlerFromConfig(cfg *Transport) func(req *http.Request) (*url.URL, e
 	return nil
 }
 
-// defaultHTTPTransport returns a new *http.Transport with the same configuration as http.DefaultTransport .
+// defaultHTTPTransport returns a new *http.Transport with the same configuration as http.DefaultTransport.
 func defaultHTTPTransport(cfg *Transport) (*http.Transport, error) {
 	// Finalise the handler loading
 	tlsConfig, err := MakeTLSConfig(cfg.ClientTLS)
@@ -127,7 +127,7 @@ func defaultHTTPTransport(cfg *Transport) (*http.Transport, error) {
 	}, nil
 }
 
-// DefaultHTTPClient returns a new *http.Client with sensible defaults, in particular it has a timeout set!
+// DefaultHTTPClient returns a new *http.Client with sensible defaults, in particular it has a timeout set.
 func DefaultHTTPClient(cfg *CommonDownstreamData) (*http.Client, error) {
 	if cfg == nil {
 		cfg = DefaultCommonDownstreamData()

--- a/config/library.go
+++ b/config/library.go
@@ -8,13 +8,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// LibraryConfig struct
+// LibraryConfig struct.
 type LibraryConfig struct {
 	Log       LogConfig `yaml:"log"`
 	Profiling bool      `yaml:"profiling"`
 }
 
-// LogConfig struct
+// LogConfig struct.
 type LogConfig struct {
 	Format       string        `yaml:"format" validate:"nonnil,oneof=color json text"`
 	Splunk       *SplunkConfig `yaml:"splunk"`
@@ -22,7 +22,7 @@ type LogConfig struct {
 	ReportCaller bool          `yaml:"caller" mapstructure:"caller"`
 }
 
-// SplunkConfig struct
+// SplunkConfig struct.
 type SplunkConfig struct {
 	TokenBase64 common.SensitiveString `yaml:"tokenBase64" validate:"nonnil,base64"`
 	Index       string                 `yaml:"index" validate:"nonnil"`

--- a/config/library_test.go
+++ b/config/library_test.go
@@ -53,7 +53,6 @@ func defaultLogConfig() LogConfig {
 	}
 }
 
-// Config
 func TestValidateDefaultConfig(t *testing.T) {
 	config := defaultConfig()
 	err := config.Validate()

--- a/config/secret_key_test.go
+++ b/config/secret_key_test.go
@@ -16,7 +16,6 @@ func TestSecretKeyConfigNil(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-//nolint:funlen // Needs to be long due to struct
 func TestSecretKeyConfigValidation(t *testing.T) {
 	testData := []struct {
 		name string

--- a/config/tls.go
+++ b/config/tls.go
@@ -84,14 +84,14 @@ type CertKeyPair struct {
 	KeyPath  *string `yaml:"keyPath"`
 }
 
-// Cert path modes
+// Cert path modes.
 const (
 	DIRMODE  = "directory"
 	FILEMODE = "file"
 	SYSMODE  = "system"
 )
 
-// Cert encoding types
+// Cert encoding types.
 const (
 	PEM = "pem"
 )

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -32,7 +32,7 @@ func (i *JSONTime) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// StringToIntPtr takes a string and converts it to an integer pointer
+// StringToIntPtr takes a string and converts it to an integer pointer.
 func StringToIntPtr(ctx context.Context, input string) (*int64, error) {
 	if input == "" {
 		return nil, nil
@@ -46,7 +46,7 @@ func StringToIntPtr(ctx context.Context, input string) (*int64, error) {
 	return &result, nil
 }
 
-// StringToBoolPtr takes a string and converts it to a bool pointer
+// StringToBoolPtr takes a string and converts it to a bool pointer.
 func StringToBoolPtr(ctx context.Context, input string) (*bool, error) {
 	if input == "" {
 		return nil, nil
@@ -63,7 +63,7 @@ func StringToBoolPtr(ctx context.Context, input string) (*bool, error) {
 	return &result, nil
 }
 
-// StringToStringPtr takes a string and converts it to a string pointer
+// StringToStringPtr takes a string and converts it to a string pointer.
 func StringToStringPtr(ctx context.Context, input string) (*string, error) {
 	if input == "" {
 		return nil, nil
@@ -73,7 +73,7 @@ func StringToStringPtr(ctx context.Context, input string) (*string, error) {
 	return &result, nil
 }
 
-// StringToTimePtr takes a string and converts it to a time.Time pointer
+// StringToTimePtr takes a string and converts it to a time.Time pointer.
 func StringToTimePtr(ctx context.Context, input string) (*JSONTime, error) {
 	if input == "" {
 		return nil, nil

--- a/core/callback.go
+++ b/core/callback.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-chi/chi"
 )
 
-// RestGenCallback is used by `sysl-go` to call hand-crafted code
+// RestGenCallback is used by `sysl-go` to call hand-crafted code.
 type RestGenCallback interface {
 	// AddMiddleware allows hand-crafted code to add middleware to the router
 	AddMiddleware(ctx context.Context, r chi.Router)
@@ -26,7 +26,7 @@ type RestGenCallback interface {
 	DownstreamTimeoutContext(ctx context.Context) (context.Context, context.CancelFunc)
 }
 
-// GrpcGenCallback is currently a subset of RestGenCallback so is defined separately for convenience
+// GrpcGenCallback is currently a subset of RestGenCallback so is defined separately for convenience.
 type GrpcGenCallback interface {
 	DownstreamTimeoutContext(ctx context.Context) (context.Context, context.CancelFunc)
 }

--- a/core/grpc.go
+++ b/core/grpc.go
@@ -90,7 +90,7 @@ func unaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServ
 	return handler(log.With("traceid", "traceid").Onto(ctx), req)
 }
 
-// NewGrpcServer creates a grpc.Server based on passed configuration
+// NewGrpcServer creates a grpc.Server based on passed configuration.
 func newGrpcServer(cfg *config.CommonServerConfig, interceptors ...grpc.UnaryServerInterceptor) (*grpc.Server, error) {
 	opts, err := config.ExtractGrpcServerOptions(cfg)
 	if err != nil {

--- a/core/http.go
+++ b/core/http.go
@@ -171,7 +171,7 @@ func configureRouters(basePath string, mWare []func(handler http.Handler) http.H
 	return rootRouter, router
 }
 
-// SelectBasePath chooses between a specified base path and a dynmaically chosen one
+// SelectBasePath chooses between a specified base path and a dynmaically chosen one.
 func SelectBasePath(fromSpec, dynamic string) string {
 	switch fromSpec {
 	case "": // fromSpec not specified

--- a/core/server.go
+++ b/core/server.go
@@ -30,7 +30,6 @@ func (e *emptyWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-//nolint:gocognit // Long method names are okay because only generated code will call this, not humans.
 func NewServerParams(ctx context.Context, name string, opts ...ServerOption) *ServerParams {
 	params := &ServerParams{Ctx: ctx, Name: name}
 	for _, o := range opts {

--- a/core/server.go
+++ b/core/server.go
@@ -159,7 +159,7 @@ func (o *logrusLoggerOption) apply(params *ServerParams) {
 	params.logrusLogger = o.logger
 }
 
-// Deprecated: Use WithPkgLogger instead
+// Deprecated: Use WithPkgLogger instead.
 func WithLogrusLogger(logger *logrus.Logger) ServerOption {
 	return &logrusLoggerOption{logger}
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -23,7 +23,7 @@ type Middleware struct {
 	getPathPattern func(ctx context.Context) string
 }
 
-// NewHTTPServerMetricsMiddleware returns a new Prometheus Middleware handler
+// NewHTTPServerMetricsMiddleware returns a new Prometheus Middleware handler.
 func NewHTTPServerMetricsMiddleware(registry *prometheus.Registry, serviceName string,
 	getPathPattern func(ctx context.Context) string) func(next http.Handler) http.Handler {
 	requestCounterVec := prometheus.NewCounterVec(

--- a/restlib/mock.go
+++ b/restlib/mock.go
@@ -21,7 +21,7 @@ type responseWriter struct {
 }
 
 // Err sets the error value returned by the Write method.
-// Chain it with construction: mock.ResponseWriter().Err(someErr)
+// Chain it with construction: mock.ResponseWriter().Err(someErr).
 func (m *responseWriter) Err(err error) *responseWriter {
 	m.err = err
 	return m

--- a/restlib/restlib.go
+++ b/restlib/restlib.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// HTTPResult is the result return by the library
+// HTTPResult is the result return by the library.
 type HTTPResult struct {
 	HTTPResponse *http.Response
 	Body         []byte
@@ -71,8 +71,8 @@ func unmarshal(resp *http.Response, body []byte, respStruct interface{}) (*HTTPR
 	return makeHTTPResult(resp, body, respStruct), nil
 }
 
-// DoHTTPRequest returns HTTPResult
-//nolint:funlen // TODO: Refactor this function to be shorter
+// DoHTTPRequest returns HTTPResult.
+//nolint:funlen // TODO: Refactor this function to be shorter.
 func DoHTTPRequest(ctx context.Context, client *http.Client, method string,
 	urlString string, body interface{}, required []string,
 	okResponse interface{}, errorResponse interface{}) (*HTTPResult, error) {
@@ -157,7 +157,7 @@ func DoHTTPRequest(ctx context.Context, client *http.Client, method string,
 	return nil, result
 }
 
-// SendHTTPResponse sends the http response to the client
+// SendHTTPResponse sends the http response to the client.
 func SendHTTPResponse(w http.ResponseWriter, httpStatus int, responses ...interface{}) {
 	w.WriteHeader(httpStatus)
 
@@ -185,7 +185,7 @@ func SendHTTPResponse(w http.ResponseWriter, httpStatus int, responses ...interf
 	}
 }
 
-// SetHeaders sets the headers in response
+// SetHeaders sets the headers in response.
 func SetHeaders(w http.ResponseWriter, headerMap http.Header) {
 	for k, v := range headerMap {
 		for _, hv := range v {
@@ -207,7 +207,7 @@ func OnRestResultHTTPResult(ctx context.Context, result *HTTPResult, err error) 
 	OnRestResult(ctx, restResult, err)
 }
 
-// OnRestResult method will be called from tests as we don't expose the HTTPResult itself
+// OnRestResult method will be called from tests as we don't expose the HTTPResult itself.
 func OnRestResult(ctx context.Context, result *common.RestResult, err error) {
 	raw := ctx.Value(common.RestResultContextKey{})
 	if raw == nil {

--- a/splunk/hook.go
+++ b/splunk/hook.go
@@ -6,21 +6,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Hook is a logrus hook for splunk
+// Hook is a logrus hook for splunk.
 type Hook struct {
 	Client *Client
 	levels []logrus.Level
 	writer *Writer
 }
 
-// NewHook creates new hook
+// NewHook creates a new hook.
 // client - splunk client instance (use NewClient)
-// level - log level
+// level - log level.
 func NewHook(client *Client, levels []logrus.Level) *Hook {
 	return &Hook{client, levels, client.Writer()}
 }
 
-// Fire triggers a splunk event
+// Fire triggers a splunk event.
 func (h *Hook) Fire(entry *logrus.Entry) error {
 	formatter := logrus.JSONFormatter{}
 
@@ -53,7 +53,7 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 	}
 }
 
-// Levels Required for logrus hook implementation
+// Levels returns the levels equired for logrus hook implementation.
 func (h *Hook) Levels() []logrus.Level {
 	return h.levels
 }

--- a/splunk/splunk.go
+++ b/splunk/splunk.go
@@ -164,7 +164,7 @@ func (c *Client) LogEvents(events []*Event) error {
 	return c.doRequest(buf)
 }
 
-// Writer is a convience method for creating an io.Writer from a Writer with default values
+// Writer is a convience method for creating an io.Writer from a Writer with default values.
 func (c *Client) Writer() *Writer {
 	return &Writer{
 		Client: c,

--- a/splunk/writer.go
+++ b/splunk/writer.go
@@ -32,13 +32,13 @@ type Writer struct {
 
 // Associates some bytes with the time they were written
 // Helpful if we have long flush intervals to more precisely record the time at which
-// a message was written
+// a message was written.
 type message struct {
 	data      interface{}
 	writtenAt time.Time
 }
 
-// Writer asynchronously writes to splunk in batches
+// Writer asynchronously writes to splunk in batches.
 func (w *Writer) Write(obj interface{}) error {
 	// only initialise once. Keep all of our buffering in one thread
 	w.once.Do(func() {
@@ -57,12 +57,12 @@ func (w *Writer) Write(obj interface{}) error {
 }
 
 // Errors returns a buffered channel of errors. Might be filled over time, might not
-// Useful if you want to record any errors hit when sending data to splunk
+// Useful if you want to record any errors hit when sending data to splunk.
 func (w *Writer) Errors() <-chan error {
 	return w.errors
 }
 
-// listen for messages
+// listen for messages.
 func (w *Writer) listen() {
 	if w.FlushInterval <= 0 {
 		w.FlushInterval = defaultInterval
@@ -94,7 +94,7 @@ func (w *Writer) listen() {
 	}
 }
 
-// send sends data to splunk, retrying upon failure
+// send sends data to splunk, retrying upon failure.
 func (w *Writer) send(messages []*message, retries int) {
 	// Create events from our data so we can send them to splunk
 	events := make([]*Event, len(messages))

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -87,7 +87,7 @@ func Validate(v interface{}) error {
 // Custom validator to manage a timeout= param
 // timeout=1ms     -> 1ms max timeout, no minimum to validate
 // timeout=1ms:10s -> timeout between 1ms (inclusive) and 10s (exclusive)
-// timeout=5s:     -> 5s min timeout, no maximum
+// timeout=5s:     -> 5s min timeout, no maximum.
 func timeoutValidatorFunc(fl vv9.FieldLevel) bool {
 	parts := strings.Split(fl.Param(), ":")
 


### PR DESCRIPTION
Mostly disable a bunch of new linters, probably due to running a newer version of golangci-lint.