### PR TITLE
handles empty downstream config

### DIFF
--- a/codegen/arrai/auto/svc_app.arrai
+++ b/codegen/arrai/auto/svc_app.arrai
@@ -95,7 +95,7 @@ let sysl = //{./sysl};
 
                     var downstream *DownstreamConfig
                     var is bool
-                    if downstream, is = cfg.GenCode.Downstream.(*DownstreamConfig); !is {
+                    if downstream, is = cfg.GenCode.Downstream.(*DownstreamConfig); !is || downstream == nil {
                         downstream = &DownstreamConfig{
                             ContextTimeout: 30,
                         }


### PR DESCRIPTION
This is for simple applications that do not have a downstream and don't require downstream config.