### PR TITLE
Prevent resource leaks

### DIFF
--- a/common/errors_go13_test.go
+++ b/common/errors_go13_test.go
@@ -43,6 +43,7 @@ func TestDownstreamError_Unwrap(t *testing.T) {
 	r.WriteHeader(http.StatusInternalServerError)
 
 	resp := r.Result()
+	defer resp.Body.Close()
 	resp.Request = &http.Request{
 		Method: "POST",
 		URL: &url.URL{

--- a/common/errors_test.go
+++ b/common/errors_test.go
@@ -54,6 +54,7 @@ func TestDownstreamError_CreateDownstreamError_Timeout(t *testing.T) {
 	r.WriteHeader(http.StatusConflict)
 
 	resp := r.Result()
+	defer resp.Body.Close()
 	resp.Request = &http.Request{
 		Method: "PUT",
 		URL: &url.URL{
@@ -82,6 +83,7 @@ func TestDownstreamError_CreateDownstreamError_UnexpectedResponse(t *testing.T) 
 	r.WriteHeader(http.StatusInternalServerError)
 
 	resp := r.Result()
+	defer resp.Body.Close()
 	resp.Request = &http.Request{
 		Method: "POST",
 		URL: &url.URL{
@@ -113,6 +115,7 @@ This is a very very long response body.`
 	r.WriteHeader(http.StatusUnauthorized)
 
 	resp := r.Result()
+	defer resp.Body.Close()
 	resp.Request = &http.Request{
 		Method: "GET",
 		URL: &url.URL{


### PR DESCRIPTION
```
$ make
[...]
golangci-lint run
common/errors_go13_test.go:45:18: response body must be closed (bodyclose)
        resp := r.Result()
                        ^
[...]
```
The linting tool has identified a potential issue with the code. It's error out that the response body obtained from r.Result() should be closed after its use to prevent resource leaks.

By using the defer statement, the resp.Body.Close() function will be executed when the surrounding function returns, ensuring the response body is always closed.